### PR TITLE
Eliminate private response body methods across all service packages

### DIFF
--- a/pkg/service/account/service_application.go
+++ b/pkg/service/account/service_application.go
@@ -12,27 +12,17 @@ func (s *Service) GetApplications(parameters connection.APIRequestParameters) ([
 }
 
 func (s *Service) GetApplicationsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Application], error) {
-	body, err := s.getApplicationsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Application](s.connection, "/account/v1/applications", parameters)
 	return connection.NewPaginated(body, parameters, s.GetApplicationsPaginated), err
-}
-
-func (s *Service) getApplicationsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Application], error) {
-	return connection.Get[[]Application](s.connection, "/account/v1/applications", parameters)
 }
 
 // GetApplication retrieves a single application by id
 func (s *Service) GetApplication(appID string) (Application, error) {
-	body, err := s.getApplicationResponseBody(appID)
-
-	return body.Data, err
-}
-
-func (s *Service) getApplicationResponseBody(appID string) (*connection.APIResponseBodyData[Application], error) {
 	if appID == "" {
-		return &connection.APIResponseBodyData[Application]{}, fmt.Errorf("invalid application id")
+		return Application{}, fmt.Errorf("invalid application id")
 	}
-
-	return connection.Get[Application](s.connection, fmt.Sprintf("/account/v1/applications/%s", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	body, err := connection.Get[Application](s.connection, fmt.Sprintf("/account/v1/applications/%s", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	return body.Data, err
 }
 
 // GetApplications retrieves a list of applications
@@ -41,142 +31,78 @@ func (s *Service) GetServices(parameters connection.APIRequestParameters) ([]App
 }
 
 func (s *Service) GetServicesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[ApplicationService], error) {
-	body, err := s.getServicesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]ApplicationService](s.connection, "/account/v1/services", parameters)
 	return connection.NewPaginated(body, parameters, s.GetServicesPaginated), err
 }
 
-func (s *Service) getServicesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ApplicationService], error) {
-	body := &connection.APIResponseBodyData[[]ApplicationService]{}
-
-	response, err := s.connection.Get("/account/v1/services", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
-}
-
 func (s *Service) CreateApplication(req CreateApplicationRequest) (CreateApplicationResponse, error) {
-	body, err := s.createApplicationResponseBody(req)
-
+	body, err := connection.Post[CreateApplicationResponse](s.connection, "/account/v1/applications", &req)
 	return body.Data, err
 }
 
-func (s *Service) createApplicationResponseBody(req CreateApplicationRequest) (*connection.APIResponseBodyData[CreateApplicationResponse], error) {
-	return connection.Post[CreateApplicationResponse](s.connection, "/account/v1/applications", &req)
-}
-
 func (s *Service) UpdateApplication(appID string, req UpdateApplicationRequest) error {
-	_, err := s.updateApplicationResponseBody(appID, req)
-
-	return err
-}
-
-func (s *Service) updateApplicationResponseBody(appID string, req UpdateApplicationRequest) (*connection.APIResponseBodyData[Application], error) {
 	if appID == "" {
-		return &connection.APIResponseBodyData[Application]{}, fmt.Errorf("invalid application id")
+		return fmt.Errorf("invalid application id")
 	}
-
-	return connection.Patch[Application](s.connection, fmt.Sprintf("/account/v1/applications/%s", appID), &req, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	_, err := connection.Patch[Application](s.connection, fmt.Sprintf("/account/v1/applications/%s", appID), &req, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	return err
 }
 
 // GetApplicationServices retrieves the services and roles of an application by id
 func (s *Service) GetApplicationServices(appID string) (ApplicationServiceMapping, error) {
-	body, err := s.getApplicationServicesResponseBody(appID)
-
+	if appID == "" {
+		return ApplicationServiceMapping{}, fmt.Errorf("invalid application id")
+	}
+	body, err := connection.Get[ApplicationServiceMapping](s.connection, fmt.Sprintf("/account/v1/applications/%s/services", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
 	return body.Data, err
 }
 
-func (s *Service) getApplicationServicesResponseBody(appID string) (*connection.APIResponseBodyData[ApplicationServiceMapping], error) {
-	if appID == "" {
-		return &connection.APIResponseBodyData[ApplicationServiceMapping]{}, fmt.Errorf("invalid application id")
-	}
-
-	return connection.Get[ApplicationServiceMapping](s.connection, fmt.Sprintf("/account/v1/applications/%s/services", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
-}
-
 func (s *Service) SetApplicationServices(appID string, req SetServiceRequest) error {
-	_, err := s.setApplicationServicesResponseBody(appID, req)
-
-	return err
-}
-
-func (s *Service) setApplicationServicesResponseBody(appID string, req SetServiceRequest) (*connection.APIResponseBodyData[interface{}], error) {
 	if appID == "" {
-		return &connection.APIResponseBodyData[interface{}]{}, fmt.Errorf("invalid application id")
+		return fmt.Errorf("invalid application id")
 	}
-
-	return connection.Put[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s/services", appID), &req, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	_, err := connection.Put[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s/services", appID), &req, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	return err
 }
 
 func (s *Service) DeleteApplicationServices(appID string) error {
-	_, err := s.deleteApplicationServicesResponseBody(appID)
-
-	return err
-}
-
-func (s *Service) deleteApplicationServicesResponseBody(appID string) (*connection.APIResponseBodyData[interface{}], error) {
 	if appID == "" {
-		return &connection.APIResponseBodyData[interface{}]{}, fmt.Errorf("invalid application id")
+		return fmt.Errorf("invalid application id")
 	}
-
-	return connection.Put[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s/services", appID), SetServiceRequest{Scopes: []ApplicationServiceScope{}}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	_, err := connection.Put[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s/services", appID), SetServiceRequest{Scopes: []ApplicationServiceScope{}}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	return err
 }
 
 // DeleteApplication removes an application
 func (s *Service) DeleteApplication(appID string) error {
-	_, err := s.deleteApplicationResponseBody(appID)
-
-	return err
-}
-
-func (s *Service) deleteApplicationResponseBody(appID string) (*connection.APIResponseBodyData[interface{}], error) {
 	if appID == "" {
-		return &connection.APIResponseBodyData[interface{}]{}, fmt.Errorf("invalid application id")
+		return fmt.Errorf("invalid application id")
 	}
-
-	return connection.Delete[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	_, err := connection.Delete[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	return err
 }
 
 // GetApplicationRestrictions retrieves the IP restrictions of an application by id
 func (s *Service) GetApplicationRestrictions(appID string) (ApplicationRestriction, error) {
-	body, err := s.getApplicationRestrictionsResponseBody(appID)
-
+	if appID == "" {
+		return ApplicationRestriction{}, fmt.Errorf("invalid application id")
+	}
+	body, err := connection.Get[ApplicationRestriction](s.connection, fmt.Sprintf("/account/v1/applications/%s/ip-restrictions", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
 	return body.Data, err
 }
 
-func (s *Service) getApplicationRestrictionsResponseBody(appID string) (*connection.APIResponseBodyData[ApplicationRestriction], error) {
-	if appID == "" {
-		return &connection.APIResponseBodyData[ApplicationRestriction]{}, fmt.Errorf("invalid application id")
-	}
-
-	return connection.Get[ApplicationRestriction](s.connection, fmt.Sprintf("/account/v1/applications/%s/ip-restrictions", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
-}
-
 func (s *Service) SetApplicationRestrictions(appID string, req SetRestrictionRequest) error {
-	_, err := s.setApplicationRestrictionsResponseBody(appID, req)
-
-	return err
-}
-
-func (s *Service) setApplicationRestrictionsResponseBody(appID string, req SetRestrictionRequest) (*connection.APIResponseBodyData[interface{}], error) {
 	if appID == "" {
-		return &connection.APIResponseBodyData[interface{}]{}, fmt.Errorf("invalid application id")
+		return fmt.Errorf("invalid application id")
 	}
-
-	return connection.Put[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s/ip-restrictions", appID), &req, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	_, err := connection.Put[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s/ip-restrictions", appID), &req, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	return err
 }
 
 func (s *Service) DeleteApplicationRestrictions(appID string) error {
-	_, err := s.deleteApplicationRestrictionsResponseBody(appID)
-
-	return err
-}
-
-func (s *Service) deleteApplicationRestrictionsResponseBody(appID string) (*connection.APIResponseBodyData[interface{}], error) {
 	if appID == "" {
-		return &connection.APIResponseBodyData[interface{}]{}, fmt.Errorf("invalid application id")
+		return fmt.Errorf("invalid application id")
 	}
-
-	return connection.Put[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s/ip-restrictions", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	_, err := connection.Put[interface{}](s.connection, fmt.Sprintf("/account/v1/applications/%s/ip-restrictions", appID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplicationNotFoundError{ID: appID}))
+	return err
 }

--- a/pkg/service/account/service_client.go
+++ b/pkg/service/account/service_client.go
@@ -13,119 +13,37 @@ func (s *Service) GetClients(parameters connection.APIRequestParameters) ([]Clie
 
 // GetClientsPaginated retrieves a paginated list of clients
 func (s *Service) GetClientsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Client], error) {
-	body, err := s.getClientsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Client](s.connection, "/account/v1/clients", parameters)
 	return connection.NewPaginated(body, parameters, s.GetClientsPaginated), err
-}
-
-func (s *Service) getClientsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Client], error) {
-	body := &connection.APIResponseBodyData[[]Client]{}
-
-	response, err := s.connection.Get("/account/v1/clients", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetClient retrieves a single client by id
 func (s *Service) GetClient(clientID int) (Client, error) {
-	body, err := s.getClientResponseBody(clientID)
-
-	return body.Data, err
-}
-
-func (s *Service) getClientResponseBody(clientID int) (*connection.APIResponseBodyData[Client], error) {
-	body := &connection.APIResponseBodyData[Client]{}
-
 	if clientID < 1 {
-		return body, fmt.Errorf("invalid client id")
+		return Client{}, fmt.Errorf("invalid client id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/account/v1/clients/%d", clientID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ClientNotFoundError{ID: clientID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Client](s.connection, fmt.Sprintf("/account/v1/clients/%d", clientID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ClientNotFoundError{ID: clientID}))
+	return body.Data, err
 }
 
 // CreateClient creates a new client
 func (s *Service) CreateClient(req CreateClientRequest) (int, error) {
-	body, err := s.createClientResponseBody(req)
-
+	body, err := connection.Post[Client](s.connection, "/account/v1/clients", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createClientResponseBody(req CreateClientRequest) (*connection.APIResponseBodyData[Client], error) {
-	body := &connection.APIResponseBodyData[Client]{}
-
-	response, err := s.connection.Post("/account/v1/clients", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchClient patches a client
 func (s *Service) PatchClient(clientID int, patch PatchClientRequest) error {
-	_, err := s.patchClientResponseBody(clientID, patch)
-
-	return err
-}
-
-func (s *Service) patchClientResponseBody(clientID int, patch PatchClientRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if clientID < 1 {
-		return body, fmt.Errorf("invalid client id")
+		return fmt.Errorf("invalid client id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/account/v1/clients/%d", clientID), &patch)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ClientNotFoundError{ID: clientID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/account/v1/clients/%d", clientID), &patch, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ClientNotFoundError{ID: clientID}))
 }
 
 // DeleteClient removes a client
 func (s *Service) DeleteClient(clientID int) error {
-	_, err := s.deleteClientResponseBody(clientID)
-
-	return err
-}
-
-func (s *Service) deleteClientResponseBody(clientID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if clientID < 1 {
-		return body, fmt.Errorf("invalid client id")
+		return fmt.Errorf("invalid client id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/account/v1/clients/%d", clientID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ClientNotFoundError{ID: clientID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/account/v1/clients/%d", clientID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ClientNotFoundError{ID: clientID}))
 }

--- a/pkg/service/account/service_contact.go
+++ b/pkg/service/account/service_contact.go
@@ -13,45 +13,15 @@ func (s *Service) GetContacts(parameters connection.APIRequestParameters) ([]Con
 
 // GetContactsPaginated retrieves a paginated list of contacts
 func (s *Service) GetContactsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Contact], error) {
-	body, err := s.getContactsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Contact](s.connection, "/account/v1/contacts", parameters)
 	return connection.NewPaginated(body, parameters, s.GetContactsPaginated), err
-}
-
-func (s *Service) getContactsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Contact], error) {
-	body := &connection.APIResponseBodyData[[]Contact]{}
-
-	response, err := s.connection.Get("/account/v1/contacts", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetContact retrieves a single contact by id
 func (s *Service) GetContact(contactID int) (Contact, error) {
-	body, err := s.getContactResponseBody(contactID)
-
-	return body.Data, err
-}
-
-func (s *Service) getContactResponseBody(contactID int) (*connection.APIResponseBodyData[Contact], error) {
-	body := &connection.APIResponseBodyData[Contact]{}
-
 	if contactID < 1 {
-		return body, fmt.Errorf("invalid contact id")
+		return Contact{}, fmt.Errorf("invalid contact id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/account/v1/contacts/%d", contactID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ContactNotFoundError{ID: contactID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Contact](s.connection, fmt.Sprintf("/account/v1/contacts/%d", contactID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ContactNotFoundError{ID: contactID}))
+	return body.Data, err
 }

--- a/pkg/service/account/service_credit.go
+++ b/pkg/service/account/service_credit.go
@@ -4,18 +4,6 @@ import "github.com/ans-group/sdk-go/pkg/connection"
 
 // GetCredits retrieves a list of credits
 func (s *Service) GetCredits(parameters connection.APIRequestParameters) ([]Credit, error) {
-	body, err := s.getCreditsResponseBody(parameters)
-
+	body, err := connection.Get[[]Credit](s.connection, "/account/v1/credits", parameters)
 	return body.Data, err
-}
-
-func (s *Service) getCreditsResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Credit], error) {
-	body := &connection.APIResponseBodyData[[]Credit]{}
-
-	response, err := s.connection.Get("/account/v1/credits", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/account/service_details.go
+++ b/pkg/service/account/service_details.go
@@ -4,18 +4,6 @@ import "github.com/ans-group/sdk-go/pkg/connection"
 
 // GetDetails retrieves account details
 func (s *Service) GetDetails() (Details, error) {
-	body, err := s.getDetailsResponseBody()
-
+	body, err := connection.Get[Details](s.connection, "/account/v1/details", connection.APIRequestParameters{})
 	return body.Data, err
-}
-
-func (s *Service) getDetailsResponseBody() (*connection.APIResponseBodyData[Details], error) {
-	body := &connection.APIResponseBodyData[Details]{}
-
-	response, err := s.connection.Get("/account/v1/details", connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/account/service_invoice.go
+++ b/pkg/service/account/service_invoice.go
@@ -13,47 +13,17 @@ func (s *Service) GetInvoices(parameters connection.APIRequestParameters) ([]Inv
 
 // GetInvoicesPaginated retrieves a paginated list of invoices
 func (s *Service) GetInvoicesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Invoice], error) {
-	body, err := s.getInvoicesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Invoice](s.connection, "/account/v1/invoices", parameters)
 	return connection.NewPaginated(body, parameters, s.GetInvoicesPaginated), err
-}
-
-func (s *Service) getInvoicesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Invoice], error) {
-	body := &connection.APIResponseBodyData[[]Invoice]{}
-
-	response, err := s.connection.Get("/account/v1/invoices", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetInvoice retrieves a single invoice by id
 func (s *Service) GetInvoice(invoiceID int) (Invoice, error) {
-	body, err := s.getInvoiceResponseBody(invoiceID)
-
-	return body.Data, err
-}
-
-func (s *Service) getInvoiceResponseBody(invoiceID int) (*connection.APIResponseBodyData[Invoice], error) {
-	body := &connection.APIResponseBodyData[Invoice]{}
-
 	if invoiceID < 1 {
-		return body, fmt.Errorf("invalid invoice id")
+		return Invoice{}, fmt.Errorf("invalid invoice id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/account/v1/invoices/%d", invoiceID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InvoiceNotFoundError{ID: invoiceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Invoice](s.connection, fmt.Sprintf("/account/v1/invoices/%d", invoiceID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&InvoiceNotFoundError{ID: invoiceID}))
+	return body.Data, err
 }
 
 // GetInvoiceQueries retrieves a list of invoice queries
@@ -63,63 +33,21 @@ func (s *Service) GetInvoiceQueries(parameters connection.APIRequestParameters) 
 
 // GetInvoiceQueriesPaginated retrieves a paginated list of invoice queries
 func (s *Service) GetInvoiceQueriesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[InvoiceQuery], error) {
-	body, err := s.getInvoiceQueriesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]InvoiceQuery](s.connection, "/account/v1/invoice-queries", parameters)
 	return connection.NewPaginated(body, parameters, s.GetInvoiceQueriesPaginated), err
-}
-
-func (s *Service) getInvoiceQueriesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]InvoiceQuery], error) {
-	body := &connection.APIResponseBodyData[[]InvoiceQuery]{}
-
-	response, err := s.connection.Get("/account/v1/invoice-queries", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetInvoiceQuery retrieves a single invoice query by id
 func (s *Service) GetInvoiceQuery(queryID int) (InvoiceQuery, error) {
-	body, err := s.getInvoiceQueryResponseBody(queryID)
-
-	return body.Data, err
-}
-
-func (s *Service) getInvoiceQueryResponseBody(queryID int) (*connection.APIResponseBodyData[InvoiceQuery], error) {
-	body := &connection.APIResponseBodyData[InvoiceQuery]{}
-
 	if queryID < 1 {
-		return body, fmt.Errorf("invalid invoice query id")
+		return InvoiceQuery{}, fmt.Errorf("invalid invoice query id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/account/v1/invoice-queries/%d", queryID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InvoiceQueryNotFoundError{ID: queryID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[InvoiceQuery](s.connection, fmt.Sprintf("/account/v1/invoice-queries/%d", queryID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&InvoiceQueryNotFoundError{ID: queryID}))
+	return body.Data, err
 }
 
 // CreateInvoiceQuery retrieves creates an InvoiceQuery
 func (s *Service) CreateInvoiceQuery(req CreateInvoiceQueryRequest) (int, error) {
-	body, err := s.createInvoiceQueryResponseBody(req)
-
+	body, err := connection.Post[InvoiceQuery](s.connection, "/account/v1/invoice-queries", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createInvoiceQueryResponseBody(req CreateInvoiceQueryRequest) (*connection.APIResponseBodyData[InvoiceQuery], error) {
-	body := &connection.APIResponseBodyData[InvoiceQuery]{}
-
-	response, err := s.connection.Post("/account/v1/invoice-queries", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/billing/service_card.go
+++ b/pkg/service/billing/service_card.go
@@ -13,119 +13,37 @@ func (s *Service) GetCards(parameters connection.APIRequestParameters) ([]Card, 
 
 // GetCardsPaginated retrieves a paginated list of cards
 func (s *Service) GetCardsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Card], error) {
-	body, err := s.getCardsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Card](s.connection, "/billing/v1/cards", parameters)
 	return connection.NewPaginated(body, parameters, s.GetCardsPaginated), err
-}
-
-func (s *Service) getCardsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Card], error) {
-	body := &connection.APIResponseBodyData[[]Card]{}
-
-	response, err := s.connection.Get("/billing/v1/cards", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetCard retrieves a single card by id
 func (s *Service) GetCard(cardID int) (Card, error) {
-	body, err := s.getCardResponseBody(cardID)
-
-	return body.Data, err
-}
-
-func (s *Service) getCardResponseBody(cardID int) (*connection.APIResponseBodyData[Card], error) {
-	body := &connection.APIResponseBodyData[Card]{}
-
 	if cardID < 1 {
-		return body, fmt.Errorf("invalid card id")
+		return Card{}, fmt.Errorf("invalid card id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/billing/v1/cards/%d", cardID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CardNotFoundError{ID: cardID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Card](s.connection, fmt.Sprintf("/billing/v1/cards/%d", cardID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CardNotFoundError{ID: cardID}))
+	return body.Data, err
 }
 
 // CreateCard creates a new card
 func (s *Service) CreateCard(req CreateCardRequest) (int, error) {
-	body, err := s.createCardResponseBody(req)
-
+	body, err := connection.Post[Card](s.connection, "/billing/v1/cards", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createCardResponseBody(req CreateCardRequest) (*connection.APIResponseBodyData[Card], error) {
-	body := &connection.APIResponseBodyData[Card]{}
-
-	response, err := s.connection.Post("/billing/v1/cards", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchCard patches a card
 func (s *Service) PatchCard(cardID int, patch PatchCardRequest) error {
-	_, err := s.patchCardResponseBody(cardID, patch)
-
-	return err
-}
-
-func (s *Service) patchCardResponseBody(cardID int, patch PatchCardRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if cardID < 1 {
-		return body, fmt.Errorf("invalid card id")
+		return fmt.Errorf("invalid card id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/billing/v1/cards/%d", cardID), &patch)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CardNotFoundError{ID: cardID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/billing/v1/cards/%d", cardID), &patch, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CardNotFoundError{ID: cardID}))
 }
 
 // DeleteCard removes a card
 func (s *Service) DeleteCard(cardID int) error {
-	_, err := s.deleteCardResponseBody(cardID)
-
-	return err
-}
-
-func (s *Service) deleteCardResponseBody(cardID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if cardID < 1 {
-		return body, fmt.Errorf("invalid card id")
+		return fmt.Errorf("invalid card id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/billing/v1/cards/%d", cardID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CardNotFoundError{ID: cardID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/billing/v1/cards/%d", cardID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CardNotFoundError{ID: cardID}))
 }

--- a/pkg/service/billing/service_cloudcost.go
+++ b/pkg/service/billing/service_cloudcost.go
@@ -13,45 +13,15 @@ func (s *Service) GetCloudCosts(parameters connection.APIRequestParameters) ([]C
 
 // GetCloudCostsPaginated retrieves a paginated list of costs
 func (s *Service) GetCloudCostsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[CloudCost], error) {
-	body, err := s.getCloudCostsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]CloudCost](s.connection, "/billing/v1/cloud-costs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetCloudCostsPaginated), err
-}
-
-func (s *Service) getCloudCostsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]CloudCost], error) {
-	body := &connection.APIResponseBodyData[[]CloudCost]{}
-
-	response, err := s.connection.Get("/billing/v1/cloud-costs", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetCloudCost retrieves a single cost by id
 func (s *Service) GetCloudCost(costID int) (CloudCost, error) {
-	body, err := s.getCloudCostResponseBody(costID)
-
-	return body.Data, err
-}
-
-func (s *Service) getCloudCostResponseBody(costID int) (*connection.APIResponseBodyData[CloudCost], error) {
-	body := &connection.APIResponseBodyData[CloudCost]{}
-
 	if costID < 1 {
-		return body, fmt.Errorf("invalid cost id")
+		return CloudCost{}, fmt.Errorf("invalid cost id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/billing/v1/cloud-costs/%d", costID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CloudCostNotFoundError{ID: costID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[CloudCost](s.connection, fmt.Sprintf("/billing/v1/cloud-costs/%d", costID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CloudCostNotFoundError{ID: costID}))
+	return body.Data, err
 }

--- a/pkg/service/billing/service_directdebit.go
+++ b/pkg/service/billing/service_directdebit.go
@@ -1,29 +1,9 @@
 package billing
 
-import (
-	"github.com/ans-group/sdk-go/pkg/connection"
-)
+import "github.com/ans-group/sdk-go/pkg/connection"
 
 // GetDirectDebit retrieves direct debit details
 func (s *Service) GetDirectDebit() (DirectDebit, error) {
-	body, err := s.getDirectDebitResponseBody()
-
+	body, err := connection.Get[DirectDebit](s.connection, "/billing/v1/direct-debit", connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DirectDebitNotFoundError{}))
 	return body.Data, err
-}
-
-func (s *Service) getDirectDebitResponseBody() (*connection.APIResponseBodyData[DirectDebit], error) {
-	body := &connection.APIResponseBodyData[DirectDebit]{}
-
-	response, err := s.connection.Get("/billing/v1/direct-debit", connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DirectDebitNotFoundError{}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/billing/service_invoice.go
+++ b/pkg/service/billing/service_invoice.go
@@ -13,45 +13,15 @@ func (s *Service) GetInvoices(parameters connection.APIRequestParameters) ([]Inv
 
 // GetInvoicesPaginated retrieves a paginated list of invoices
 func (s *Service) GetInvoicesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Invoice], error) {
-	body, err := s.getInvoicesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Invoice](s.connection, "/billing/v1/invoices", parameters)
 	return connection.NewPaginated(body, parameters, s.GetInvoicesPaginated), err
-}
-
-func (s *Service) getInvoicesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Invoice], error) {
-	body := &connection.APIResponseBodyData[[]Invoice]{}
-
-	response, err := s.connection.Get("/billing/v1/invoices", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetInvoice retrieves a single invoice by id
 func (s *Service) GetInvoice(invoiceID int) (Invoice, error) {
-	body, err := s.getInvoiceResponseBody(invoiceID)
-
-	return body.Data, err
-}
-
-func (s *Service) getInvoiceResponseBody(invoiceID int) (*connection.APIResponseBodyData[Invoice], error) {
-	body := &connection.APIResponseBodyData[Invoice]{}
-
 	if invoiceID < 1 {
-		return body, fmt.Errorf("invalid invoice id")
+		return Invoice{}, fmt.Errorf("invalid invoice id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/billing/v1/invoices/%d", invoiceID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InvoiceNotFoundError{ID: invoiceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Invoice](s.connection, fmt.Sprintf("/billing/v1/invoices/%d", invoiceID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&InvoiceNotFoundError{ID: invoiceID}))
+	return body.Data, err
 }

--- a/pkg/service/billing/service_invoicequery.go
+++ b/pkg/service/billing/service_invoicequery.go
@@ -13,63 +13,21 @@ func (s *Service) GetInvoiceQueries(parameters connection.APIRequestParameters) 
 
 // GetInvoiceQueriesPaginated retrieves a paginated list of invoice queries
 func (s *Service) GetInvoiceQueriesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[InvoiceQuery], error) {
-	body, err := s.getInvoiceQueriesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]InvoiceQuery](s.connection, "/billing/v1/invoice-queries", parameters)
 	return connection.NewPaginated(body, parameters, s.GetInvoiceQueriesPaginated), err
-}
-
-func (s *Service) getInvoiceQueriesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]InvoiceQuery], error) {
-	body := &connection.APIResponseBodyData[[]InvoiceQuery]{}
-
-	response, err := s.connection.Get("/billing/v1/invoice-queries", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetInvoiceQuery retrieves a single invoice query by id
 func (s *Service) GetInvoiceQuery(queryID int) (InvoiceQuery, error) {
-	body, err := s.getInvoiceQueryResponseBody(queryID)
-
-	return body.Data, err
-}
-
-func (s *Service) getInvoiceQueryResponseBody(queryID int) (*connection.APIResponseBodyData[InvoiceQuery], error) {
-	body := &connection.APIResponseBodyData[InvoiceQuery]{}
-
 	if queryID < 1 {
-		return body, fmt.Errorf("invalid invoice query id")
+		return InvoiceQuery{}, fmt.Errorf("invalid invoice query id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/billing/v1/invoice-queries/%d", queryID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InvoiceQueryNotFoundError{ID: queryID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[InvoiceQuery](s.connection, fmt.Sprintf("/billing/v1/invoice-queries/%d", queryID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&InvoiceQueryNotFoundError{ID: queryID}))
+	return body.Data, err
 }
 
 // CreateInvoiceQuery retrieves creates an InvoiceQuery
 func (s *Service) CreateInvoiceQuery(req CreateInvoiceQueryRequest) (int, error) {
-	body, err := s.createInvoiceQueryResponseBody(req)
-
+	body, err := connection.Post[InvoiceQuery](s.connection, "/billing/v1/invoice-queries", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createInvoiceQueryResponseBody(req CreateInvoiceQueryRequest) (*connection.APIResponseBodyData[InvoiceQuery], error) {
-	body := &connection.APIResponseBodyData[InvoiceQuery]{}
-
-	response, err := s.connection.Post("/billing/v1/invoice-queries", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/billing/service_payment.go
+++ b/pkg/service/billing/service_payment.go
@@ -13,45 +13,15 @@ func (s *Service) GetPayments(parameters connection.APIRequestParameters) ([]Pay
 
 // GetPaymentsPaginated retrieves a paginated list of payments
 func (s *Service) GetPaymentsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Payment], error) {
-	body, err := s.getPaymentsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Payment](s.connection, "/billing/v1/payments", parameters)
 	return connection.NewPaginated(body, parameters, s.GetPaymentsPaginated), err
-}
-
-func (s *Service) getPaymentsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Payment], error) {
-	body := &connection.APIResponseBodyData[[]Payment]{}
-
-	response, err := s.connection.Get("/billing/v1/payments", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetPayment retrieves a single payment by id
 func (s *Service) GetPayment(paymentID int) (Payment, error) {
-	body, err := s.getPaymentResponseBody(paymentID)
-
-	return body.Data, err
-}
-
-func (s *Service) getPaymentResponseBody(paymentID int) (*connection.APIResponseBodyData[Payment], error) {
-	body := &connection.APIResponseBodyData[Payment]{}
-
 	if paymentID < 1 {
-		return body, fmt.Errorf("invalid payment id")
+		return Payment{}, fmt.Errorf("invalid payment id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/billing/v1/payments/%d", paymentID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &PaymentNotFoundError{ID: paymentID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Payment](s.connection, fmt.Sprintf("/billing/v1/payments/%d", paymentID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&PaymentNotFoundError{ID: paymentID}))
+	return body.Data, err
 }

--- a/pkg/service/billing/service_recurringcost.go
+++ b/pkg/service/billing/service_recurringcost.go
@@ -13,45 +13,15 @@ func (s *Service) GetRecurringCosts(parameters connection.APIRequestParameters) 
 
 // GetRecurringCostsPaginated retrieves a paginated list of costs
 func (s *Service) GetRecurringCostsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[RecurringCost], error) {
-	body, err := s.getRecurringCostsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]RecurringCost](s.connection, "/billing/v1/recurring-costs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetRecurringCostsPaginated), err
-}
-
-func (s *Service) getRecurringCostsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]RecurringCost], error) {
-	body := &connection.APIResponseBodyData[[]RecurringCost]{}
-
-	response, err := s.connection.Get("/billing/v1/recurring-costs", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetRecurringCost retrieves a single cost by id
 func (s *Service) GetRecurringCost(costID int) (RecurringCost, error) {
-	body, err := s.getRecurringCostResponseBody(costID)
-
-	return body.Data, err
-}
-
-func (s *Service) getRecurringCostResponseBody(costID int) (*connection.APIResponseBodyData[RecurringCost], error) {
-	body := &connection.APIResponseBodyData[RecurringCost]{}
-
 	if costID < 1 {
-		return body, fmt.Errorf("invalid cost id")
+		return RecurringCost{}, fmt.Errorf("invalid cost id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/billing/v1/recurring-costs/%d", costID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RecurringCostNotFoundError{ID: costID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[RecurringCost](s.connection, fmt.Sprintf("/billing/v1/recurring-costs/%d", costID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&RecurringCostNotFoundError{ID: costID}))
+	return body.Data, err
 }

--- a/pkg/service/cloudflare/service_account.go
+++ b/pkg/service/cloudflare/service_account.go
@@ -13,107 +13,39 @@ func (s *Service) GetAccounts(parameters connection.APIRequestParameters) ([]Acc
 
 // GetAccountsPaginated retrieves a paginated list of accounts
 func (s *Service) GetAccountsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Account], error) {
-	body, err := s.getAccountsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Account](s.connection, "/cloudflare/v1/accounts", parameters)
 	return connection.NewPaginated(body, parameters, s.GetAccountsPaginated), err
-}
-
-func (s *Service) getAccountsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Account], error) {
-	body := &connection.APIResponseBodyData[[]Account]{}
-
-	response, err := s.connection.Get("/cloudflare/v1/accounts", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetAccount retrieves a single account by id
 func (s *Service) GetAccount(accountID string) (Account, error) {
-	body, err := s.getAccountResponseBody(accountID)
-
-	return body.Data, err
-}
-
-func (s *Service) getAccountResponseBody(accountID string) (*connection.APIResponseBodyData[Account], error) {
-	body := &connection.APIResponseBodyData[Account]{}
-
 	if accountID == "" {
-		return body, fmt.Errorf("invalid account id")
+		return Account{}, fmt.Errorf("invalid account id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/cloudflare/v1/accounts/%s", accountID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AccountNotFoundError{ID: accountID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Account](s.connection, fmt.Sprintf("/cloudflare/v1/accounts/%s", accountID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&AccountNotFoundError{ID: accountID}))
+	return body.Data, err
 }
 
 // CreateAccount creates a new account
 func (s *Service) CreateAccount(req CreateAccountRequest) (string, error) {
-	body, err := s.createAccountResponseBody(req)
-
+	body, err := connection.Post[Account](s.connection, "/cloudflare/v1/accounts", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createAccountResponseBody(req CreateAccountRequest) (*connection.APIResponseBodyData[Account], error) {
-	body := &connection.APIResponseBodyData[Account]{}
-
-	response, err := s.connection.Post("/cloudflare/v1/accounts", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchAccount updates an account
 func (s *Service) PatchAccount(accountID string, req PatchAccountRequest) error {
-	_, err := s.patchAccountResponseBody(accountID, req)
-
-	return err
-}
-
-func (s *Service) patchAccountResponseBody(accountID string, req PatchAccountRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if accountID == "" {
-		return body, fmt.Errorf("invalid account id")
+		return fmt.Errorf("invalid account id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/cloudflare/v1/accounts/%s", accountID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
+	_, err := connection.Post[struct{}](s.connection, fmt.Sprintf("/cloudflare/v1/accounts/%s", accountID), &req)
+	return err
 }
 
 // CreateAccount creates a new account member
 func (s *Service) CreateAccountMember(accountID string, req CreateAccountMemberRequest) error {
-	_, err := s.createAccountMemberResponseBody(accountID, req)
-
-	return err
-}
-
-func (s *Service) createAccountMemberResponseBody(accountID string, req CreateAccountMemberRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if accountID == "" {
-		return body, fmt.Errorf("invalid account id")
+		return fmt.Errorf("invalid account id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/cloudflare/v1/accounts/%s/members", accountID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
+	_, err := connection.Post[struct{}](s.connection, fmt.Sprintf("/cloudflare/v1/accounts/%s/members", accountID), &req)
+	return err
 }

--- a/pkg/service/cloudflare/service_orchestrator.go
+++ b/pkg/service/cloudflare/service_orchestrator.go
@@ -6,18 +6,6 @@ import (
 
 // CreateOrchestration creates a new orchestration request
 func (s *Service) CreateOrchestration(req CreateOrchestrationRequest) error {
-	_, err := s.createOrchestrationResponseBody(req)
-
+	_, err := connection.Post[struct{}](s.connection, "/cloudflare/v1/orchestrator", &req)
 	return err
-}
-
-func (s *Service) createOrchestrationResponseBody(req CreateOrchestrationRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
-	response, err := s.connection.Post("/cloudflare/v1/orchestrator", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/cloudflare/service_spendplan.go
+++ b/pkg/service/cloudflare/service_spendplan.go
@@ -11,17 +11,6 @@ func (s *Service) GetSpendPlans(parameters connection.APIRequestParameters) ([]S
 
 // GetSpendPlansPaginated retrieves a paginated list of spend plans
 func (s *Service) GetSpendPlansPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[SpendPlan], error) {
-	body, err := s.getSpendPlansPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]SpendPlan](s.connection, "/cloudflare/v1/spend-plans", parameters)
 	return connection.NewPaginated(body, parameters, s.GetSpendPlansPaginated), err
-}
-
-func (s *Service) getSpendPlansPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]SpendPlan], error) {
-	body := &connection.APIResponseBodyData[[]SpendPlan]{}
-
-	response, err := s.connection.Get("/cloudflare/v1/spend-plans", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/cloudflare/service_subscription.go
+++ b/pkg/service/cloudflare/service_subscription.go
@@ -11,17 +11,6 @@ func (s *Service) GetSubscriptions(parameters connection.APIRequestParameters) (
 
 // GetSubscriptionsPaginated retrieves a paginated list of subscriptions
 func (s *Service) GetSubscriptionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Subscription], error) {
-	body, err := s.getSubscriptionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Subscription](s.connection, "/cloudflare/v1/subscriptions", parameters)
 	return connection.NewPaginated(body, parameters, s.GetSubscriptionsPaginated), err
-}
-
-func (s *Service) getSubscriptionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Subscription], error) {
-	body := &connection.APIResponseBodyData[[]Subscription]{}
-
-	response, err := s.connection.Get("/cloudflare/v1/subscriptions", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/cloudflare/service_totalspend.go
+++ b/pkg/service/cloudflare/service_totalspend.go
@@ -6,17 +6,6 @@ import (
 
 // GetTotalSpendMonthToDate retrieves a total spend for current month
 func (s *Service) GetTotalSpendMonthToDate() (TotalSpend, error) {
-	body, err := s.getTotalSpendMonthToDateResponseBody()
-
+	body, err := connection.Get[TotalSpend](s.connection, "/cloudflare/v1/total-spend/month-to-date", connection.APIRequestParameters{})
 	return body.Data, err
-}
-
-func (s *Service) getTotalSpendMonthToDateResponseBody() (*connection.APIResponseBodyData[TotalSpend], error) {
-	body := &connection.APIResponseBodyData[TotalSpend]{}
-	response, err := s.connection.Get("/cloudflare/v1/total-spend/month-to-date", connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/cloudflare/service_zone.go
+++ b/pkg/service/cloudflare/service_zone.go
@@ -13,113 +13,38 @@ func (s *Service) GetZones(parameters connection.APIRequestParameters) ([]Zone, 
 
 // GetZonesPaginated retrieves a paginated list of zones
 func (s *Service) GetZonesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Zone], error) {
-	body, err := s.getZonesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Zone](s.connection, "/cloudflare/v1/zones", parameters)
 	return connection.NewPaginated(body, parameters, s.GetZonesPaginated), err
-}
-
-func (s *Service) getZonesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Zone], error) {
-	body := &connection.APIResponseBodyData[[]Zone]{}
-
-	response, err := s.connection.Get("/cloudflare/v1/zones", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetZone retrieves a single zone by id
 func (s *Service) GetZone(zoneID string) (Zone, error) {
-	body, err := s.getZoneResponseBody(zoneID)
-
-	return body.Data, err
-}
-
-func (s *Service) getZoneResponseBody(zoneID string) (*connection.APIResponseBodyData[Zone], error) {
-	body := &connection.APIResponseBodyData[Zone]{}
-
 	if zoneID == "" {
-		return body, fmt.Errorf("invalid zone id")
+		return Zone{}, fmt.Errorf("invalid zone id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/cloudflare/v1/zones/%s", zoneID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneNotFoundError{ID: zoneID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Zone](s.connection, fmt.Sprintf("/cloudflare/v1/zones/%s", zoneID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ZoneNotFoundError{ID: zoneID}))
+	return body.Data, err
 }
 
 // CreateZone creates a new zone
 func (s *Service) CreateZone(req CreateZoneRequest) (string, error) {
-	body, err := s.createZoneResponseBody(req)
-
+	body, err := connection.Post[Zone](s.connection, "/cloudflare/v1/zones", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createZoneResponseBody(req CreateZoneRequest) (*connection.APIResponseBodyData[Zone], error) {
-	body := &connection.APIResponseBodyData[Zone]{}
-
-	response, err := s.connection.Post("/cloudflare/v1/zones", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchZone updates a zone
 func (s *Service) PatchZone(zoneID string, req PatchZoneRequest) error {
-	_, err := s.patchZoneResponseBody(zoneID, req)
-
-	return err
-}
-
-func (s *Service) patchZoneResponseBody(zoneID string, req PatchZoneRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if zoneID == "" {
-		return body, fmt.Errorf("invalid zone id")
+		return fmt.Errorf("invalid zone id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/cloudflare/v1/zones/%s", zoneID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
+	_, err := connection.Post[struct{}](s.connection, fmt.Sprintf("/cloudflare/v1/zones/%s", zoneID), &req)
+	return err
 }
 
 // DeleteZone removes a single zone by id
 func (s *Service) DeleteZone(zoneID string) error {
-	_, err := s.deleteZoneResponseBody(zoneID)
-
-	return err
-}
-
-func (s *Service) deleteZoneResponseBody(zoneID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if zoneID == "" {
-		return body, fmt.Errorf("invalid zone id")
+		return fmt.Errorf("invalid zone id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/cloudflare/v1/zones/%s", zoneID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneNotFoundError{ID: zoneID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/cloudflare/v1/zones/%s", zoneID), connection.APIRequestParameters{}, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ZoneNotFoundError{ID: zoneID}))
 }

--- a/pkg/service/ddosx/service_domain.go
+++ b/pkg/service/ddosx/service_domain.go
@@ -15,121 +15,39 @@ func (s *Service) GetDomains(parameters connection.APIRequestParameters) ([]Doma
 
 // GetDomainsPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Domain], error) {
-	body, err := s.getDomainsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Domain](s.connection, "/ddosx/v1/domains", parameters)
 	return connection.NewPaginated(body, parameters, s.GetDomainsPaginated), err
-}
-
-func (s *Service) getDomainsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Domain], error) {
-	body := &connection.APIResponseBodyData[[]Domain]{}
-
-	response, err := s.connection.Get("/ddosx/v1/domains", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetDomain retrieves a single domain by name
 func (s *Service) GetDomain(domainName string) (Domain, error) {
-	body, err := s.getDomainResponseBody(domainName)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainResponseBody(domainName string) (*connection.APIResponseBodyData[Domain], error) {
-	body := &connection.APIResponseBodyData[Domain]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return Domain{}, fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Domain](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s", domainName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data, err
 }
 
 // CreateDomain creates a new domain
 func (s *Service) CreateDomain(req CreateDomainRequest) error {
-	_, err := s.createDomainResponseBody(req)
-
+	_, err := connection.Post[struct{}](s.connection, "/ddosx/v1/domains", &req)
 	return err
-}
-
-func (s *Service) createDomainResponseBody(req CreateDomainRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
-	response, err := s.connection.Post("/ddosx/v1/domains", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // DeleteDomain removes a domain
 func (s *Service) DeleteDomain(domainName string, req DeleteDomainRequest) error {
-	_, err := s.deleteDomainResponseBody(domainName, req)
-
-	return err
-}
-
-func (s *Service) deleteDomainResponseBody(domainName string, req DeleteDomainRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s", domainName), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 }
 
 // DeployDomain deploys/commits changes to a domain
 func (s *Service) DeployDomain(domainName string) error {
-	_, err := s.deployDomainResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) deployDomainResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/deploy", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/deploy", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 }
 
 // GetDomainRecords retrieves a list of records
@@ -141,153 +59,56 @@ func (s *Service) GetDomainRecords(domainName string, parameters connection.APIR
 
 // GetDomainRecordsPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainRecordsPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-	body, err := s.getDomainRecordsPaginatedResponseBody(domainName, parameters)
-
+	if domainName == "" {
+		return nil, fmt.Errorf("invalid domain name")
+	}
+	body, err := connection.Get[[]Record](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records", domainName), parameters, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Record], error) {
 		return s.GetDomainRecordsPaginated(domainName, p)
 	}), err
 }
 
-func (s *Service) getDomainRecordsPaginatedResponseBody(domainName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Record], error) {
-	body := &connection.APIResponseBodyData[[]Record]{}
-
-	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/records", domainName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
-}
-
 // GetDomainRecord retrieves a single domain record by ID
 func (s *Service) GetDomainRecord(domainName string, recordID string) (Record, error) {
-	body, err := s.getDomainRecordResponseBody(domainName, recordID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainRecordResponseBody(domainName string, recordID string) (*connection.APIResponseBodyData[Record], error) {
-	body := &connection.APIResponseBodyData[Record]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return Record{}, fmt.Errorf("invalid domain name")
 	}
 	if recordID == "" {
-		return body, fmt.Errorf("invalid record ID")
+		return Record{}, fmt.Errorf("invalid record ID")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/records/%s", domainName, recordID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainRecordNotFoundError{DomainName: domainName, ID: recordID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Record](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records/%s", domainName, recordID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainRecordNotFoundError{DomainName: domainName, ID: recordID}))
+	return body.Data, err
 }
 
 // CreateDomainRecord creates a new record for a domain
 func (s *Service) CreateDomainRecord(domainName string, req CreateRecordRequest) (string, error) {
-	body, err := s.createDomainRecordResponseBody(domainName, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createDomainRecordResponseBody(domainName string, req CreateRecordRequest) (*connection.APIResponseBodyData[Record], error) {
-	body := &connection.APIResponseBodyData[Record]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return "", fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/records", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[Record](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data.ID, err
 }
 
 // PatchDomainRecord patches a single domain record by ID
 func (s *Service) PatchDomainRecord(domainName string, recordID string, req PatchRecordRequest) error {
-	_, err := s.patchDomainRecordResponseBody(domainName, recordID, req)
-
-	return err
-}
-
-func (s *Service) patchDomainRecordResponseBody(domainName string, recordID string, req PatchRecordRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if recordID == "" {
-		return body, fmt.Errorf("invalid record ID")
+		return fmt.Errorf("invalid record ID")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/records/%s", domainName, recordID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainRecordNotFoundError{ID: recordID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records/%s", domainName, recordID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainRecordNotFoundError{ID: recordID}))
 }
 
 // DeleteDomainRecord deletes a single domain record by ID
 func (s *Service) DeleteDomainRecord(domainName string, recordID string) error {
-	_, err := s.deleteDomainRecordResponseBody(domainName, recordID)
-
-	return err
-}
-
-func (s *Service) deleteDomainRecordResponseBody(domainName string, recordID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if recordID == "" {
-		return body, fmt.Errorf("invalid record ID")
+		return fmt.Errorf("invalid record ID")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/records/%s", domainName, recordID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainRecordNotFoundError{ID: recordID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records/%s", domainName, recordID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainRecordNotFoundError{ID: recordID}))
 }
 
 // GetDomainProperties retrieves a list of domain properties
@@ -299,206 +120,69 @@ func (s *Service) GetDomainProperties(domainName string, parameters connection.A
 
 // GetDomainPropertiesPaginated retrieves a paginated list of domain properties
 func (s *Service) GetDomainPropertiesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[DomainProperty], error) {
-	body, err := s.getDomainPropertiesPaginatedResponseBody(domainName, parameters)
-
+	if domainName == "" {
+		return nil, fmt.Errorf("invalid domain name")
+	}
+	body, err := connection.Get[[]DomainProperty](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/properties", domainName), parameters, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[DomainProperty], error) {
 		return s.GetDomainPropertiesPaginated(domainName, p)
 	}), err
 }
 
-func (s *Service) getDomainPropertiesPaginatedResponseBody(domainName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]DomainProperty], error) {
-	body := &connection.APIResponseBodyData[[]DomainProperty]{}
-
-	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/properties", domainName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
-}
-
 // GetDomainProperty retrieves a single domain property by ID
 func (s *Service) GetDomainProperty(domainName string, propertyID string) (DomainProperty, error) {
-	body, err := s.getDomainPropertyResponseBody(domainName, propertyID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainPropertyResponseBody(domainName string, propertyID string) (*connection.APIResponseBodyData[DomainProperty], error) {
-	body := &connection.APIResponseBodyData[DomainProperty]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return DomainProperty{}, fmt.Errorf("invalid domain name")
 	}
 	if propertyID == "" {
-		return body, fmt.Errorf("invalid property ID")
+		return DomainProperty{}, fmt.Errorf("invalid property ID")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/properties/%s", domainName, propertyID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainPropertyNotFoundError{ID: propertyID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[DomainProperty](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/properties/%s", domainName, propertyID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainPropertyNotFoundError{ID: propertyID}))
+	return body.Data, err
 }
 
 // PatchDomainProperty patches a single domain property by ID
 func (s *Service) PatchDomainProperty(domainName string, propertyID string, req PatchDomainPropertyRequest) error {
-	_, err := s.patchDomainPropertyResponseBody(domainName, propertyID, req)
-
-	return err
-}
-
-func (s *Service) patchDomainPropertyResponseBody(domainName string, propertyID string, req PatchDomainPropertyRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if propertyID == "" {
-		return body, fmt.Errorf("invalid property ID")
+		return fmt.Errorf("invalid property ID")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/properties/%s", domainName, propertyID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainPropertyNotFoundError{ID: propertyID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/properties/%s", domainName, propertyID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainPropertyNotFoundError{ID: propertyID}))
 }
 
 // GetDomainWAF retrieves the WAF configuration for a domain
 func (s *Service) GetDomainWAF(domainName string) (WAF, error) {
-	body, err := s.getDomainWAFResponseBody(domainName)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainWAFResponseBody(domainName string) (*connection.APIResponseBodyData[WAF], error) {
-	body := &connection.APIResponseBodyData[WAF]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return WAF{}, fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/waf", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainWAFNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[WAF](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf", domainName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
+	return body.Data, err
 }
 
 // CreateDomainWAF creates the WAF configuration for a domain
 func (s *Service) CreateDomainWAF(domainName string, req CreateWAFRequest) error {
-	_, err := s.createDomainWAFResponseBody(domainName, req)
-
-	return err
-}
-
-func (s *Service) createDomainWAFResponseBody(domainName string, req CreateWAFRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/waf", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf", domainName), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 }
 
 // PatchDomainWAF patches the WAF configuration for a domain
 func (s *Service) PatchDomainWAF(domainName string, req PatchWAFRequest) error {
-	_, err := s.patchDomainWAFResponseBody(domainName, req)
-
-	return err
-}
-
-func (s *Service) patchDomainWAFResponseBody(domainName string, req PatchWAFRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/waf", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainWAFNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf", domainName), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
 }
 
 // DeleteDomainWAF deletes the WAF configuration for a domain
 func (s *Service) DeleteDomainWAF(domainName string) error {
-	_, err := s.deleteDomainWAFResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) deleteDomainWAFResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/waf", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainWAFNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
 }
 
 // GetDomainWAFRuleSets retrieves a list of rulesets
@@ -510,93 +194,36 @@ func (s *Service) GetDomainWAFRuleSets(domainName string, parameters connection.
 
 // GetDomainWAFRuleSetsPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainWAFRuleSetsPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[WAFRuleSet], error) {
-	body, err := s.getDomainWAFRuleSetsPaginatedResponseBody(domainName, parameters)
+	if domainName == "" {
+		return nil, fmt.Errorf("invalid domain name")
+	}
+	body, err := connection.Get[[]WAFRuleSet](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets", domainName), parameters, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[WAFRuleSet], error) {
 		return s.GetDomainWAFRuleSetsPaginated(domainName, p)
 	}), err
 }
 
-func (s *Service) getDomainWAFRuleSetsPaginatedResponseBody(domainName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]WAFRuleSet], error) {
-	body := &connection.APIResponseBodyData[[]WAFRuleSet]{}
-
-	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets", domainName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainWAFNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
-}
-
 // GetDomainWAFRuleSet retrieves a waf advanced rule set for a domain
 func (s *Service) GetDomainWAFRuleSet(domainName string, ruleSetID string) (WAFRuleSet, error) {
-	body, err := s.getDomainWAFRuleSetResponseBody(domainName, ruleSetID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainWAFRuleSetResponseBody(domainName string, ruleSetID string) (*connection.APIResponseBodyData[WAFRuleSet], error) {
-	body := &connection.APIResponseBodyData[WAFRuleSet]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return WAFRuleSet{}, fmt.Errorf("invalid domain name")
 	}
 	if ruleSetID == "" {
-		return body, fmt.Errorf("invalid rule set ID")
+		return WAFRuleSet{}, fmt.Errorf("invalid rule set ID")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets/%s", domainName, ruleSetID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFRuleSetNotFoundError{ID: ruleSetID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[WAFRuleSet](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets/%s", domainName, ruleSetID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&WAFRuleSetNotFoundError{ID: ruleSetID}))
+	return body.Data, err
 }
 
 // PatchDomainWAFRuleSet patches a waf advanced rule set for a domain
 func (s *Service) PatchDomainWAFRuleSet(domainName string, ruleSetID string, req PatchWAFRuleSetRequest) error {
-	_, err := s.patchDomainWAFRuleSetResponseBody(domainName, ruleSetID, req)
-
-	return err
-}
-
-func (s *Service) patchDomainWAFRuleSetResponseBody(domainName string, ruleSetID string, req PatchWAFRuleSetRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleSetID == "" {
-		return body, fmt.Errorf("invalid rule set ID")
+		return fmt.Errorf("invalid rule set ID")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets/%s", domainName, ruleSetID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFRuleSetNotFoundError{ID: ruleSetID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets/%s", domainName, ruleSetID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFRuleSetNotFoundError{ID: ruleSetID}))
 }
 
 // GetDomainWAFRules retrieves a list of rules
@@ -608,153 +235,56 @@ func (s *Service) GetDomainWAFRules(domainName string, parameters connection.API
 
 // GetDomainWAFRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainWAFRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[WAFRule], error) {
-	body, err := s.getDomainWAFRulesPaginatedResponseBody(domainName, parameters)
-
+	if domainName == "" {
+		return nil, fmt.Errorf("invalid domain name")
+	}
+	body, err := connection.Get[[]WAFRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules", domainName), parameters, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[WAFRule], error) {
 		return s.GetDomainWAFRulesPaginated(domainName, p)
 	}), err
 }
 
-func (s *Service) getDomainWAFRulesPaginatedResponseBody(domainName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]WAFRule], error) {
-	body := &connection.APIResponseBodyData[[]WAFRule]{}
-
-	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules", domainName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainWAFNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
-}
-
 // GetDomainWAFRule retrieves a waf rule for a domain
 func (s *Service) GetDomainWAFRule(domainName string, ruleID string) (WAFRule, error) {
-	body, err := s.getDomainWAFRuleResponseBody(domainName, ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainWAFRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBodyData[WAFRule], error) {
-	body := &connection.APIResponseBodyData[WAFRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return WAFRule{}, fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return WAFRule{}, fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules/%s", domainName, ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[WAFRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&WAFRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // CreateDomainWAFRule creates a WAF rule
 func (s *Service) CreateDomainWAFRule(domainName string, req CreateWAFRuleRequest) (string, error) {
-	body, err := s.createDomainWAFRuleResponseBody(domainName, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createDomainWAFRuleResponseBody(domainName string, req CreateWAFRuleRequest) (*connection.APIResponseBodyData[WAFRule], error) {
-	body := &connection.APIResponseBodyData[WAFRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return "", fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[WAFRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data.ID, err
 }
 
 // PatchDomainWAFRule patches a waf rule for a domain
 func (s *Service) PatchDomainWAFRule(domainName string, ruleID string, req PatchWAFRuleRequest) error {
-	_, err := s.patchDomainWAFRuleResponseBody(domainName, ruleID, req)
-
-	return err
-}
-
-func (s *Service) patchDomainWAFRuleResponseBody(domainName string, ruleID string, req PatchWAFRuleRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules/%s", domainName, ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules/%s", domainName, ruleID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFRuleNotFoundError{ID: ruleID}))
 }
 
 // DeleteDomainWAFRule deletes a waf rule for a domain
 func (s *Service) DeleteDomainWAFRule(domainName string, ruleID string) error {
-	_, err := s.deleteDomainWAFRuleResponseBody(domainName, ruleID)
-
-	return err
-}
-
-func (s *Service) deleteDomainWAFRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules/%s", domainName, ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFRuleNotFoundError{ID: ruleID}))
 }
 
 // GetDomainWAFAdvancedRules retrieves a list of rules
@@ -766,153 +296,56 @@ func (s *Service) GetDomainWAFAdvancedRules(domainName string, parameters connec
 
 // GetDomainWAFAdvancedRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainWAFAdvancedRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[WAFAdvancedRule], error) {
-	body, err := s.getDomainWAFAdvancedRulesPaginatedResponseBody(domainName, parameters)
-
+	if domainName == "" {
+		return nil, fmt.Errorf("invalid domain name")
+	}
+	body, err := connection.Get[[]WAFAdvancedRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules", domainName), parameters, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[WAFAdvancedRule], error) {
 		return s.GetDomainWAFAdvancedRulesPaginated(domainName, p)
 	}), err
 }
 
-func (s *Service) getDomainWAFAdvancedRulesPaginatedResponseBody(domainName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]WAFAdvancedRule], error) {
-	body := &connection.APIResponseBodyData[[]WAFAdvancedRule]{}
-
-	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules", domainName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainWAFNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
-}
-
 // GetDomainWAFAdvancedRule retrieves a waf rule for a domain
 func (s *Service) GetDomainWAFAdvancedRule(domainName string, ruleID string) (WAFAdvancedRule, error) {
-	body, err := s.getDomainWAFAdvancedRuleResponseBody(domainName, ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainWAFAdvancedRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBodyData[WAFAdvancedRule], error) {
-	body := &connection.APIResponseBodyData[WAFAdvancedRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return WAFAdvancedRule{}, fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return WAFAdvancedRule{}, fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules/%s", domainName, ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFAdvancedRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[WAFAdvancedRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&WAFAdvancedRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // CreateDomainWAFAdvancedRule creates a WAF rule
 func (s *Service) CreateDomainWAFAdvancedRule(domainName string, req CreateWAFAdvancedRuleRequest) (string, error) {
-	body, err := s.createDomainWAFAdvancedRuleResponseBody(domainName, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createDomainWAFAdvancedRuleResponseBody(domainName string, req CreateWAFAdvancedRuleRequest) (*connection.APIResponseBodyData[WAFAdvancedRule], error) {
-	body := &connection.APIResponseBodyData[WAFAdvancedRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return "", fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[WAFAdvancedRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data.ID, err
 }
 
 // PatchDomainWAFAdvancedRule patches a waf advanced rule for a domain
 func (s *Service) PatchDomainWAFAdvancedRule(domainName string, ruleID string, req PatchWAFAdvancedRuleRequest) error {
-	_, err := s.patchDomainWAFAdvancedRuleResponseBody(domainName, ruleID, req)
-
-	return err
-}
-
-func (s *Service) patchDomainWAFAdvancedRuleResponseBody(domainName string, ruleID string, req PatchWAFAdvancedRuleRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules/%s", domainName, ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFAdvancedRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules/%s", domainName, ruleID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFAdvancedRuleNotFoundError{ID: ruleID}))
 }
 
 // DeleteDomainWAFAdvancedRule deletees a waf advanced rule for a domain
 func (s *Service) DeleteDomainWAFAdvancedRule(domainName string, ruleID string) error {
-	_, err := s.deleteDomainWAFAdvancedRuleResponseBody(domainName, ruleID)
-
-	return err
-}
-
-func (s *Service) deleteDomainWAFAdvancedRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules/%s", domainName, ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFAdvancedRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFAdvancedRuleNotFoundError{ID: ruleID}))
 }
 
 // GetDomainACLGeoIPRules retrieves a list of rules
@@ -924,209 +357,74 @@ func (s *Service) GetDomainACLGeoIPRules(domainName string, parameters connectio
 
 // GetDomainACLGeoIPRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainACLGeoIPRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[ACLGeoIPRule], error) {
-	body, err := s.getDomainACLGeoIPRulesPaginatedResponseBody(domainName, parameters)
-
+	if domainName == "" {
+		return nil, fmt.Errorf("invalid domain name")
+	}
+	body, err := connection.Get[[]ACLGeoIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips", domainName), parameters, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ACLGeoIPRule], error) {
 		return s.GetDomainACLGeoIPRulesPaginated(domainName, p)
 	}), err
 }
 
-func (s *Service) getDomainACLGeoIPRulesPaginatedResponseBody(domainName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ACLGeoIPRule], error) {
-	body := &connection.APIResponseBodyData[[]ACLGeoIPRule]{}
-
-	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips", domainName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
-}
-
 // GetDomainACLGeoIPRule retrieves a single ACL GeoIP rule for a domain
 func (s *Service) GetDomainACLGeoIPRule(domainName string, ruleID string) (ACLGeoIPRule, error) {
-	body, err := s.getDomainACLGeoIPRuleResponseBody(domainName, ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainACLGeoIPRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBodyData[ACLGeoIPRule], error) {
-	body := &connection.APIResponseBodyData[ACLGeoIPRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return ACLGeoIPRule{}, fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return ACLGeoIPRule{}, fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/%s", domainName, ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ACLGeoIPRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[ACLGeoIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ACLGeoIPRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // CreateDomainACLGeoIPRule creates an ACL GeoIP rule
 func (s *Service) CreateDomainACLGeoIPRule(domainName string, req CreateACLGeoIPRuleRequest) (string, error) {
-	body, err := s.createDomainACLGeoIPRuleResponseBody(domainName, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createDomainACLGeoIPRuleResponseBody(domainName string, req CreateACLGeoIPRuleRequest) (*connection.APIResponseBodyData[ACLGeoIPRule], error) {
-	body := &connection.APIResponseBodyData[ACLGeoIPRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return "", fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[ACLGeoIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data.ID, err
 }
 
 // PatchDomainACLGeoIPRule patches an ACL GeoIP rule
 func (s *Service) PatchDomainACLGeoIPRule(domainName string, ruleID string, req PatchACLGeoIPRuleRequest) error {
-	_, err := s.patchDomainACLGeoIPRuleResponseBody(domainName, ruleID, req)
-
-	return err
-}
-
-func (s *Service) patchDomainACLGeoIPRuleResponseBody(domainName string, ruleID string, req PatchACLGeoIPRuleRequest) (*connection.APIResponseBodyData[ACLGeoIPRule], error) {
-	body := &connection.APIResponseBodyData[ACLGeoIPRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/%s", domainName, ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ACLGeoIPRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	_, err := connection.Patch[ACLGeoIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/%s", domainName, ruleID), &req, connection.NotFoundResponseHandler(&ACLGeoIPRuleNotFoundError{ID: ruleID}))
+	return err
 }
 
 // DeleteDomainACLGeoIPRule deletes an ACL GeoIP rule
 func (s *Service) DeleteDomainACLGeoIPRule(domainName string, ruleID string) error {
-	_, err := s.deleteDomainACLGeoIPRuleResponseBody(domainName, ruleID)
-
-	return err
-}
-
-func (s *Service) deleteDomainACLGeoIPRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/%s", domainName, ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ACLGeoIPRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ACLGeoIPRuleNotFoundError{ID: ruleID}))
 }
 
 // GetDomainACLGeoIPRulesMode retrieves the mode for ACL GeoIP rules
 func (s *Service) GetDomainACLGeoIPRulesMode(domainName string) (ACLGeoIPRulesMode, error) {
-	body, err := s.getDomainACLGeoIPRulesModeResponseBody(domainName)
-
-	return body.Data.Mode, err
-}
-
-func (s *Service) getDomainACLGeoIPRulesModeResponseBody(domainName string) (*connection.APIResponseBodyData[GetACLGeoIPRulesModeResponseBodyData], error) {
-	body := &connection.APIResponseBodyData[GetACLGeoIPRulesModeResponseBodyData]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return "", fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/mode", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[GetACLGeoIPRulesModeResponseBodyData](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/mode", domainName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data.Mode, err
 }
 
 // PatchDomainACLGeoIPRulesMode patches the mode for ACL GeoIP rules
 func (s *Service) PatchDomainACLGeoIPRulesMode(domainName string, req PatchACLGeoIPRulesModeRequest) error {
-	_, err := s.patchDomainACLGeoIPRulesModeResponseBody(domainName, req)
-
-	return err
-}
-
-func (s *Service) patchDomainACLGeoIPRulesModeResponseBody(domainName string, req PatchACLGeoIPRulesModeRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/mode", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/mode", domainName), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 }
 
 // GetDomainACLIPRules retrieves a list of rules
@@ -1138,152 +436,57 @@ func (s *Service) GetDomainACLIPRules(domainName string, parameters connection.A
 
 // GetDomainACLIPRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainACLIPRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[ACLIPRule], error) {
-	body, err := s.getDomainACLIPRulesPaginatedResponseBody(domainName, parameters)
+	if domainName == "" {
+		return nil, fmt.Errorf("invalid domain name")
+	}
+	body, err := connection.Get[[]ACLIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips", domainName), parameters, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ACLIPRule], error) {
 		return s.GetDomainACLIPRulesPaginated(domainName, p)
 	}), err
 }
 
-func (s *Service) getDomainACLIPRulesPaginatedResponseBody(domainName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ACLIPRule], error) {
-	body := &connection.APIResponseBodyData[[]ACLIPRule]{}
-
-	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips", domainName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainWAFNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
-}
-
 // GetDomainACLIPRule retrieves a single ACL IP rule for a domain
 func (s *Service) GetDomainACLIPRule(domainName string, ruleID string) (ACLIPRule, error) {
-	body, err := s.getDomainACLIPRuleResponseBody(domainName, ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainACLIPRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBodyData[ACLIPRule], error) {
-	body := &connection.APIResponseBodyData[ACLIPRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return ACLIPRule{}, fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return ACLIPRule{}, fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips/%s", domainName, ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ACLIPRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[ACLIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ACLIPRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // CreateDomainACLIPRule creates an ACL IP rule
 func (s *Service) CreateDomainACLIPRule(domainName string, req CreateACLIPRuleRequest) (string, error) {
-	body, err := s.createDomainACLIPRuleResponseBody(domainName, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createDomainACLIPRuleResponseBody(domainName string, req CreateACLIPRuleRequest) (*connection.APIResponseBodyData[ACLIPRule], error) {
-	body := &connection.APIResponseBodyData[ACLIPRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return "", fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[ACLIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data.ID, err
 }
 
 // PatchDomainACLIPRule patches an ACL IP rule
 func (s *Service) PatchDomainACLIPRule(domainName string, ruleID string, req PatchACLIPRuleRequest) error {
-	_, err := s.patchDomainACLIPRuleResponseBody(domainName, ruleID, req)
-
-	return err
-}
-
-func (s *Service) patchDomainACLIPRuleResponseBody(domainName string, ruleID string, req PatchACLIPRuleRequest) (*connection.APIResponseBodyData[ACLIPRule], error) {
-	body := &connection.APIResponseBodyData[ACLIPRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips/%s", domainName, ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ACLIPRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	_, err := connection.Patch[ACLIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips/%s", domainName, ruleID), &req, connection.NotFoundResponseHandler(&ACLIPRuleNotFoundError{ID: ruleID}))
+	return err
 }
 
 // DeleteDomainACLIPRule deletes an ACL IP rule
 func (s *Service) DeleteDomainACLIPRule(domainName string, ruleID string) error {
-	_, err := s.deleteDomainACLIPRuleResponseBody(domainName, ruleID)
-
-	return err
-}
-
-func (s *Service) deleteDomainACLIPRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips/%s", domainName, ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ACLIPRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ACLIPRuleNotFoundError{ID: ruleID}))
 }
 
 // DownloadDomainVerificationFile downloads the verification file for a domain, returning
@@ -1341,148 +544,43 @@ func (s *Service) downloadDomainVerificationFileResponse(domainName string) (*co
 
 // VerifyDomainDNS verifies a domain via DNS method
 func (s *Service) VerifyDomainDNS(domainName string) error {
-	_, err := s.verifyDomainDNSResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) verifyDomainDNSResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/verify/dns", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-		if response.StatusCode == 400 {
-			return &DomainAlreadyVerifiedError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/verify/dns", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}), connection.StatusCodeResponseHandler(400, &DomainAlreadyVerifiedError{Name: domainName}))
 }
 
 // VerifyDomainFileUpload verifies a domain via file-upload method
 func (s *Service) VerifyDomainFileUpload(domainName string) error {
-	_, err := s.verifyDomainFileUploadResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) verifyDomainFileUploadResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/verify/file-upload", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-		if response.StatusCode == 400 {
-			return &DomainAlreadyVerifiedError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/verify/file-upload", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}), connection.StatusCodeResponseHandler(400, &DomainAlreadyVerifiedError{Name: domainName}))
 }
 
 // AddDomainCDNConfiguration adds CDN configuration to a domain
 func (s *Service) AddDomainCDNConfiguration(domainName string) error {
-	_, err := s.addDomainCDNConfigurationResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) addDomainCDNConfigurationResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/cdn", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 }
 
 // DeleteDomainCDNConfiguration removes CDN configuration from a domain
 func (s *Service) DeleteDomainCDNConfiguration(domainName string) error {
-	_, err := s.deleteDomainCDNConfigurationResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) deleteDomainCDNConfigurationResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/cdn", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainCDNConfigurationNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainCDNConfigurationNotFoundError{DomainName: domainName}))
 }
 
 // CreateDomainCDNRule creates a CDN rule
 func (s *Service) CreateDomainCDNRule(domainName string, req CreateCDNRuleRequest) (string, error) {
-	body, err := s.createDomainCDNRuleResponseBody(domainName, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createDomainCDNRuleResponseBody(domainName string, req CreateCDNRuleRequest) (*connection.APIResponseBodyData[CDNRule], error) {
-	body := &connection.APIResponseBodyData[CDNRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return "", fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainCDNConfigurationNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[CDNRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules", domainName), &req, connection.NotFoundResponseHandler(&DomainCDNConfigurationNotFoundError{DomainName: domainName}))
+	return body.Data.ID, err
 }
 
 // GetDomainCDNRules retrieves a list of rules
@@ -1494,264 +592,89 @@ func (s *Service) GetDomainCDNRules(domainName string, parameters connection.API
 
 // GetDomainCDNRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainCDNRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[CDNRule], error) {
-	body, err := s.getDomainCDNRulesPaginatedResponseBody(domainName, parameters)
+	if domainName == "" {
+		return nil, fmt.Errorf("invalid domain name")
+	}
+	body, err := connection.Get[[]CDNRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules", domainName), parameters, connection.NotFoundResponseHandler(&DomainCDNConfigurationNotFoundError{DomainName: domainName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[CDNRule], error) {
 		return s.GetDomainCDNRulesPaginated(domainName, p)
 	}), err
 }
 
-func (s *Service) getDomainCDNRulesPaginatedResponseBody(domainName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]CDNRule], error) {
-	body := &connection.APIResponseBodyData[[]CDNRule]{}
-
-	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules", domainName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainCDNConfigurationNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
-}
-
 // GetDomainCDNRule retrieves a CDN rule
 func (s *Service) GetDomainCDNRule(domainName string, ruleID string) (CDNRule, error) {
-	body, err := s.getDomainCDNRuleResponseBody(domainName, ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainCDNRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBodyData[CDNRule], error) {
-	body := &connection.APIResponseBodyData[CDNRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return CDNRule{}, fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return CDNRule{}, fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules/%s", domainName, ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CDNRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[CDNRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CDNRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // PatchDomainCDNRule patches a CDN rule
 func (s *Service) PatchDomainCDNRule(domainName string, ruleID string, req PatchCDNRuleRequest) error {
-	_, err := s.patchDomainCDNRuleResponseBody(domainName, ruleID, req)
-
-	return err
-}
-
-func (s *Service) patchDomainCDNRuleResponseBody(domainName string, ruleID string, req PatchCDNRuleRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules/%s", domainName, ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CDNRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules/%s", domainName, ruleID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CDNRuleNotFoundError{ID: ruleID}))
 }
 
 // DeleteDomainCDNRule removes a CDN rule
 func (s *Service) DeleteDomainCDNRule(domainName string, ruleID string) error {
-	_, err := s.deleteDomainCDNRuleResponseBody(domainName, ruleID)
-
-	return err
-}
-
-func (s *Service) deleteDomainCDNRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules/%s", domainName, ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CDNRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CDNRuleNotFoundError{ID: ruleID}))
 }
 
 // PurgeDomainCDN purges cached content
 func (s *Service) PurgeDomainCDN(domainName string, req PurgeCDNRequest) error {
-	_, err := s.purgeDomainCDNRuleResponseBody(domainName, req)
-
-	return err
-}
-
-func (s *Service) purgeDomainCDNRuleResponseBody(domainName string, req PurgeCDNRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/cdn/purge", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainCDNConfigurationNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/purge", domainName), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainCDNConfigurationNotFoundError{DomainName: domainName}))
 }
 
 // GetDomainHSTSConfiguration retrieves the HSTS configuration for a domain
 func (s *Service) GetDomainHSTSConfiguration(domainName string) (HSTSConfiguration, error) {
-	body, err := s.getDomainHSTSConfigurationResponseBody(domainName)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainHSTSConfigurationResponseBody(domainName string) (*connection.APIResponseBodyData[HSTSConfiguration], error) {
-	body := &connection.APIResponseBodyData[HSTSConfiguration]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return HSTSConfiguration{}, fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/hsts", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainHSTSConfigurationNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[HSTSConfiguration](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts", domainName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainHSTSConfigurationNotFoundError{DomainName: domainName}))
+	return body.Data, err
 }
 
 // AddDomainHSTSConfiguration adds HSTS headers to a domain
 func (s *Service) AddDomainHSTSConfiguration(domainName string) error {
-	_, err := s.addDomainHSTSConfigurationResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) addDomainHSTSConfigurationResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/hsts", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 }
 
 // DeleteDomainHSTSConfiguration removes HSTS headers to a domain
 func (s *Service) DeleteDomainHSTSConfiguration(domainName string) error {
-	_, err := s.deleteDomainHSTSConfigurationResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) deleteDomainHSTSConfigurationResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/hsts", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainHSTSConfigurationNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainHSTSConfigurationNotFoundError{DomainName: domainName}))
 }
 
 // CreateDomainHSTSRule creates a HSTS rule
 func (s *Service) CreateDomainHSTSRule(domainName string, req CreateHSTSRuleRequest) (string, error) {
-	body, err := s.createDomainHSTSRuleResponseBody(domainName, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createDomainHSTSRuleResponseBody(domainName string, req CreateHSTSRuleRequest) (*connection.APIResponseBodyData[HSTSRule], error) {
-	body := &connection.APIResponseBodyData[HSTSRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return "", fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules", domainName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainHSTSConfigurationNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[HSTSRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules", domainName), &req, connection.NotFoundResponseHandler(&DomainHSTSConfigurationNotFoundError{DomainName: domainName}))
+	return body.Data.ID, err
 }
 
 // GetDomainHSTSRules retrieves a list of rules
@@ -1763,178 +686,61 @@ func (s *Service) GetDomainHSTSRules(domainName string, parameters connection.AP
 
 // GetDomainHSTSRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainHSTSRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[HSTSRule], error) {
-	body, err := s.getDomainHSTSRulesPaginatedResponseBody(domainName, parameters)
+	if domainName == "" {
+		return nil, fmt.Errorf("invalid domain name")
+	}
+	body, err := connection.Get[[]HSTSRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules", domainName), parameters, connection.NotFoundResponseHandler(&DomainHSTSConfigurationNotFoundError{DomainName: domainName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[HSTSRule], error) {
 		return s.GetDomainHSTSRulesPaginated(domainName, p)
 	}), err
 }
 
-func (s *Service) getDomainHSTSRulesPaginatedResponseBody(domainName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]HSTSRule], error) {
-	body := &connection.APIResponseBodyData[[]HSTSRule]{}
-
-	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules", domainName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainHSTSConfigurationNotFoundError{DomainName: domainName}
-		}
-
-		return nil
-	})
-}
-
 // GetDomainHSTSRule retrieves a HSTS rule
 func (s *Service) GetDomainHSTSRule(domainName string, ruleID string) (HSTSRule, error) {
-	body, err := s.getDomainHSTSRuleResponseBody(domainName, ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainHSTSRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBodyData[HSTSRule], error) {
-	body := &connection.APIResponseBodyData[HSTSRule]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return HSTSRule{}, fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return HSTSRule{}, fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules/%s", domainName, ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HSTSRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[HSTSRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&HSTSRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // PatchDomainHSTSRule patches a HSTS rule
 func (s *Service) PatchDomainHSTSRule(domainName string, ruleID string, req PatchHSTSRuleRequest) error {
-	_, err := s.patchDomainHSTSRuleResponseBody(domainName, ruleID, req)
-
-	return err
-}
-
-func (s *Service) patchDomainHSTSRuleResponseBody(domainName string, ruleID string, req PatchHSTSRuleRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules/%s", domainName, ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HSTSRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules/%s", domainName, ruleID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&HSTSRuleNotFoundError{ID: ruleID}))
 }
 
 // DeleteDomainHSTSRule removes a HSTS rule
 func (s *Service) DeleteDomainHSTSRule(domainName string, ruleID string) error {
-	_, err := s.deleteDomainHSTSRuleResponseBody(domainName, ruleID)
-
-	return err
-}
-
-func (s *Service) deleteDomainHSTSRuleResponseBody(domainName string, ruleID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid rule ID")
+		return fmt.Errorf("invalid rule ID")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules/%s", domainName, ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HSTSRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&HSTSRuleNotFoundError{ID: ruleID}))
 }
 
 // ActivateDomainDNSRouting activates DNS routing for a domain
 func (s *Service) ActivateDomainDNSRouting(domainName string) error {
-	_, err := s.activateDomainDNSRoutingResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) activateDomainDNSRoutingResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ddosx/v1/domains/%s/dns/active", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/dns/active", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 }
 
 // DeactivateDomainDNSRouting deactivates DNS routing for a domain
 func (s *Service) DeactivateDomainDNSRouting(domainName string) error {
-	_, err := s.deactivateDomainDNSRoutingResponseBody(domainName)
-
-	return err
-}
-
-func (s *Service) deactivateDomainDNSRoutingResponseBody(domainName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/domains/%s/dns/active", domainName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/dns/active", domainName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
 }

--- a/pkg/service/ddosx/service_record.go
+++ b/pkg/service/ddosx/service_record.go
@@ -11,17 +11,6 @@ func (s *Service) GetRecords(parameters connection.APIRequestParameters) ([]Reco
 
 // GetRecordsPaginated retrieves a paginated list of domains
 func (s *Service) GetRecordsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-	body, err := s.getRecordsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Record](s.connection, "/ddosx/v1/records", parameters)
 	return connection.NewPaginated(body, parameters, s.GetRecordsPaginated), err
-}
-
-func (s *Service) getRecordsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Record], error) {
-	body := &connection.APIResponseBodyData[[]Record]{}
-
-	response, err := s.connection.Get("/ddosx/v1/records", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/ddosx/service_ssl.go
+++ b/pkg/service/ddosx/service_ssl.go
@@ -13,175 +13,56 @@ func (s *Service) GetSSLs(parameters connection.APIRequestParameters) ([]SSL, er
 
 // GetSSLsPaginated retrieves a paginated list of ssls
 func (s *Service) GetSSLsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[SSL], error) {
-	body, err := s.getSSLsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]SSL](s.connection, "/ddosx/v1/ssls", parameters)
 	return connection.NewPaginated(body, parameters, s.GetSSLsPaginated), err
-}
-
-func (s *Service) getSSLsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]SSL], error) {
-	body := &connection.APIResponseBodyData[[]SSL]{}
-
-	response, err := s.connection.Get("/ddosx/v1/ssls", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetSSL retrieves a single ssl by id
 func (s *Service) GetSSL(sslID string) (SSL, error) {
-	body, err := s.getSSLResponseBody(sslID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSSLResponseBody(sslID string) (*connection.APIResponseBodyData[SSL], error) {
-	body := &connection.APIResponseBodyData[SSL]{}
-
 	if sslID == "" {
-		return body, fmt.Errorf("invalid ssl id")
+		return SSL{}, fmt.Errorf("invalid ssl id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/ssls/%s", sslID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SSLNotFoundError{ID: sslID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[SSL](s.connection, fmt.Sprintf("/ddosx/v1/ssls/%s", sslID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&SSLNotFoundError{ID: sslID}))
+	return body.Data, err
 }
 
 // CreateSSL retrieves creates an SSL
 func (s *Service) CreateSSL(req CreateSSLRequest) (string, error) {
-	body, err := s.createSSLResponseBody(req)
-
+	body, err := connection.Post[SSL](s.connection, "/ddosx/v1/ssls", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createSSLResponseBody(req CreateSSLRequest) (*connection.APIResponseBodyData[SSL], error) {
-	body := &connection.APIResponseBodyData[SSL]{}
-
-	response, err := s.connection.Post("/ddosx/v1/ssls", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchSSL retrieves patches an SSL
 func (s *Service) PatchSSL(sslID string, req PatchSSLRequest) (string, error) {
-	body, err := s.patchSSLResponseBody(sslID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) patchSSLResponseBody(sslID string, req PatchSSLRequest) (*connection.APIResponseBodyData[SSL], error) {
-	body := &connection.APIResponseBodyData[SSL]{}
-
 	if sslID == "" {
-		return body, fmt.Errorf("invalid ssl id")
+		return "", fmt.Errorf("invalid ssl id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ddosx/v1/ssls/%s", sslID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SSLNotFoundError{ID: sslID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[SSL](s.connection, fmt.Sprintf("/ddosx/v1/ssls/%s", sslID), &req, connection.NotFoundResponseHandler(&SSLNotFoundError{ID: sslID}))
+	return body.Data.ID, err
 }
 
 // DeleteSSL deletes patches an SSL
 func (s *Service) DeleteSSL(sslID string) error {
-	_, err := s.deleteSSLResponseBody(sslID)
-
-	return err
-}
-
-func (s *Service) deleteSSLResponseBody(sslID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if sslID == "" {
-		return body, fmt.Errorf("invalid ssl id")
+		return fmt.Errorf("invalid ssl id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ddosx/v1/ssls/%s", sslID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SSLNotFoundError{ID: sslID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/ssls/%s", sslID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&SSLNotFoundError{ID: sslID}))
 }
 
 // GetSSLContent retrieves a single ssl by id
 func (s *Service) GetSSLContent(sslID string) (SSLContent, error) {
-	body, err := s.getSSLContentResponseBody(sslID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSSLContentResponseBody(sslID string) (*connection.APIResponseBodyData[SSLContent], error) {
-	body := &connection.APIResponseBodyData[SSLContent]{}
-
 	if sslID == "" {
-		return body, fmt.Errorf("invalid ssl id")
+		return SSLContent{}, fmt.Errorf("invalid ssl id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/ssls/%s/certificates", sslID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SSLNotFoundError{ID: sslID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[SSLContent](s.connection, fmt.Sprintf("/ddosx/v1/ssls/%s/certificates", sslID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&SSLNotFoundError{ID: sslID}))
+	return body.Data, err
 }
 
 // GetSSLPrivateKey retrieves a single ssl by id
 func (s *Service) GetSSLPrivateKey(sslID string) (SSLPrivateKey, error) {
-	body, err := s.getSSLPrivateKeyResponseBody(sslID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSSLPrivateKeyResponseBody(sslID string) (*connection.APIResponseBodyData[SSLPrivateKey], error) {
-	body := &connection.APIResponseBodyData[SSLPrivateKey]{}
-
 	if sslID == "" {
-		return body, fmt.Errorf("invalid ssl id")
+		return SSLPrivateKey{}, fmt.Errorf("invalid ssl id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/ssls/%s/private-key", sslID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SSLNotFoundError{ID: sslID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[SSLPrivateKey](s.connection, fmt.Sprintf("/ddosx/v1/ssls/%s/private-key", sslID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&SSLNotFoundError{ID: sslID}))
+	return body.Data, err
 }

--- a/pkg/service/ddosx/service_waf.go
+++ b/pkg/service/ddosx/service_waf.go
@@ -13,47 +13,17 @@ func (s *Service) GetWAFLogs(parameters connection.APIRequestParameters) ([]WAFL
 
 // GetWAFLogsPaginated retrieves a paginated list of logs
 func (s *Service) GetWAFLogsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[WAFLog], error) {
-	body, err := s.getWAFLogsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]WAFLog](s.connection, "/ddosx/v1/waf/logs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetWAFLogsPaginated), err
-}
-
-func (s *Service) getWAFLogsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]WAFLog], error) {
-	body := &connection.APIResponseBodyData[[]WAFLog]{}
-
-	response, err := s.connection.Get("/ddosx/v1/waf/logs", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetWAFLog retrieves a single log by id
 func (s *Service) GetWAFLog(requestID string) (WAFLog, error) {
-	body, err := s.getWAFLogResponseBody(requestID)
-
-	return body.Data, err
-}
-
-func (s *Service) getWAFLogResponseBody(requestID string) (*connection.APIResponseBodyData[WAFLog], error) {
-	body := &connection.APIResponseBodyData[WAFLog]{}
-
 	if requestID == "" {
-		return body, fmt.Errorf("invalid request id")
+		return WAFLog{}, fmt.Errorf("invalid request id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/waf/logs/%s", requestID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFLogNotFoundError{ID: requestID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[WAFLog](s.connection, fmt.Sprintf("/ddosx/v1/waf/logs/%s", requestID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&WAFLogNotFoundError{ID: requestID}))
+	return body.Data, err
 }
 
 // GetWAFLogMatches retrieves a list of log matches
@@ -63,19 +33,8 @@ func (s *Service) GetWAFLogMatches(parameters connection.APIRequestParameters) (
 
 // GetWAFLogMatchesPaginated retrieves a paginated list of log matches
 func (s *Service) GetWAFLogMatchesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[WAFLogMatch], error) {
-	body, err := s.getWAFLogMatchesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]WAFLogMatch](s.connection, "/ddosx/v1/waf/logs/matches", parameters)
 	return connection.NewPaginated(body, parameters, s.GetWAFLogMatchesPaginated), err
-}
-
-func (s *Service) getWAFLogMatchesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]WAFLogMatch], error) {
-	body := &connection.APIResponseBodyData[[]WAFLogMatch]{}
-
-	response, err := s.connection.Get("/ddosx/v1/waf/logs/matches", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetWAFLogRequestMatches retrieves a list of log matches for request
@@ -87,62 +46,23 @@ func (s *Service) GetWAFLogRequestMatches(requestID string, parameters connectio
 
 // GetWAFLogRequestMatchesPaginated retrieves a paginated list of matches for request
 func (s *Service) GetWAFLogRequestMatchesPaginated(requestID string, parameters connection.APIRequestParameters) (*connection.Paginated[WAFLogMatch], error) {
-	body, err := s.getWAFLogRequestMatchesPaginatedResponseBody(requestID, parameters)
-
+	if requestID == "" {
+		return nil, fmt.Errorf("invalid request id")
+	}
+	body, err := connection.Get[[]WAFLogMatch](s.connection, fmt.Sprintf("/ddosx/v1/waf/logs/%s/matches", requestID), parameters, connection.NotFoundResponseHandler(&WAFLogNotFoundError{ID: requestID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[WAFLogMatch], error) {
 		return s.GetWAFLogRequestMatchesPaginated(requestID, p)
 	}), err
 }
 
-func (s *Service) getWAFLogRequestMatchesPaginatedResponseBody(requestID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]WAFLogMatch], error) {
-	body := &connection.APIResponseBodyData[[]WAFLogMatch]{}
-
-	if requestID == "" {
-		return body, fmt.Errorf("invalid request id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/waf/logs/%s/matches", requestID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFLogNotFoundError{ID: requestID}
-		}
-
-		return nil
-	})
-}
-
 // GetWAFLogRequestMatch retrieves a single waf log request match
 func (s *Service) GetWAFLogRequestMatch(requestID string, matchID string) (WAFLogMatch, error) {
-	body, err := s.getWAFLogRequestMatchResponseBody(requestID, matchID)
-
-	return body.Data, err
-}
-
-func (s *Service) getWAFLogRequestMatchResponseBody(requestID string, matchID string) (*connection.APIResponseBodyData[WAFLogMatch], error) {
-	body := &connection.APIResponseBodyData[WAFLogMatch]{}
-
 	if requestID == "" {
-		return body, fmt.Errorf("invalid request id")
+		return WAFLogMatch{}, fmt.Errorf("invalid request id")
 	}
-
 	if matchID == "" {
-		return body, fmt.Errorf("invalid match id")
+		return WAFLogMatch{}, fmt.Errorf("invalid match id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ddosx/v1/waf/logs/%s/matches/%s", requestID, matchID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &WAFLogMatchNotFoundError{ID: requestID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[WAFLogMatch](s.connection, fmt.Sprintf("/ddosx/v1/waf/logs/%s/matches/%s", requestID, matchID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&WAFLogMatchNotFoundError{ID: requestID}))
+	return body.Data, err
 }

--- a/pkg/service/draas/service_billingtype.go
+++ b/pkg/service/draas/service_billingtype.go
@@ -13,45 +13,15 @@ func (s *Service) GetBillingTypes(parameters connection.APIRequestParameters) ([
 
 // GetBillingTypesPaginated retrieves a paginated list of solutions
 func (s *Service) GetBillingTypesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[BillingType], error) {
-	body, err := s.getBillingTypesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]BillingType](s.connection, "/draas/v1/billing-types", parameters)
 	return connection.NewPaginated(body, parameters, s.GetBillingTypesPaginated), err
-}
-
-func (s *Service) getBillingTypesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]BillingType], error) {
-	body := &connection.APIResponseBodyData[[]BillingType]{}
-
-	response, err := s.connection.Get("/draas/v1/billing-types", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetBillingType retrieves a single solution by id
 func (s *Service) GetBillingType(billingTypeID string) (BillingType, error) {
-	body, err := s.getBillingTypeResponseBody(billingTypeID)
-
-	return body.Data, err
-}
-
-func (s *Service) getBillingTypeResponseBody(billingTypeID string) (*connection.APIResponseBodyData[BillingType], error) {
-	body := &connection.APIResponseBodyData[BillingType]{}
-
 	if billingTypeID == "" {
-		return body, fmt.Errorf("invalid billing type id")
+		return BillingType{}, fmt.Errorf("invalid billing type id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/billing-types/%s", billingTypeID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &BillingTypeNotFoundError{ID: billingTypeID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[BillingType](s.connection, fmt.Sprintf("/draas/v1/billing-types/%s", billingTypeID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&BillingTypeNotFoundError{ID: billingTypeID}))
+	return body.Data, err
 }

--- a/pkg/service/draas/service_iopstier.go
+++ b/pkg/service/draas/service_iopstier.go
@@ -13,45 +13,15 @@ func (s *Service) GetIOPSTiers(parameters connection.APIRequestParameters) ([]IO
 
 // GetIOPSTiersPaginated retrieves a paginated list of solutions
 func (s *Service) GetIOPSTiersPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[IOPSTier], error) {
-	body, err := s.getIOPSTiersPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]IOPSTier](s.connection, "/draas/v1/iops-tiers", parameters)
 	return connection.NewPaginated(body, parameters, s.GetIOPSTiersPaginated), err
-}
-
-func (s *Service) getIOPSTiersPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]IOPSTier], error) {
-	body := &connection.APIResponseBodyData[[]IOPSTier]{}
-
-	response, err := s.connection.Get("/draas/v1/iops-tiers", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetIOPSTier retrieves a single solution by id
 func (s *Service) GetIOPSTier(iopsTierID string) (IOPSTier, error) {
-	body, err := s.getIOPSTierResponseBody(iopsTierID)
-
-	return body.Data, err
-}
-
-func (s *Service) getIOPSTierResponseBody(iopsTierID string) (*connection.APIResponseBodyData[IOPSTier], error) {
-	body := &connection.APIResponseBodyData[IOPSTier]{}
-
 	if iopsTierID == "" {
-		return body, fmt.Errorf("invalid iops tier id")
+		return IOPSTier{}, fmt.Errorf("invalid iops tier id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/iops-tiers/%s", iopsTierID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &IOPSTierNotFoundError{ID: iopsTierID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[IOPSTier](s.connection, fmt.Sprintf("/draas/v1/iops-tiers/%s", iopsTierID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&IOPSTierNotFoundError{ID: iopsTierID}))
+	return body.Data, err
 }

--- a/pkg/service/draas/service_solution.go
+++ b/pkg/service/draas/service_solution.go
@@ -13,75 +13,25 @@ func (s *Service) GetSolutions(parameters connection.APIRequestParameters) ([]So
 
 // GetSolutionsPaginated retrieves a paginated list of solutions
 func (s *Service) GetSolutionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Solution], error) {
-	body, err := s.getSolutionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Solution](s.connection, "/draas/v1/solutions", parameters)
 	return connection.NewPaginated(body, parameters, s.GetSolutionsPaginated), err
-}
-
-func (s *Service) getSolutionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Solution], error) {
-	body := &connection.APIResponseBodyData[[]Solution]{}
-
-	response, err := s.connection.Get("/draas/v1/solutions", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetSolution retrieves a single solution by id
 func (s *Service) GetSolution(solutionID string) (Solution, error) {
-	body, err := s.getSolutionResponseBody(solutionID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSolutionResponseBody(solutionID string) (*connection.APIResponseBodyData[Solution], error) {
-	body := &connection.APIResponseBodyData[Solution]{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return Solution{}, fmt.Errorf("invalid solution id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s", solutionID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Solution](s.connection, fmt.Sprintf("/draas/v1/solutions/%s", solutionID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
+	return body.Data, err
 }
 
 // PatchSolution patches a solution by ID
 func (s *Service) PatchSolution(solutionID string, req PatchSolutionRequest) error {
-	_, err := s.patchSolutionResponseBody(solutionID, req)
-
-	return err
-}
-
-func (s *Service) patchSolutionResponseBody(solutionID string, req PatchSolutionRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/draas/v1/solutions/%s", solutionID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/draas/v1/solutions/%s", solutionID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 }
 
 // GetSolutionBackupResources retrieves a collection of backup resources for specified solution
@@ -93,88 +43,30 @@ func (s *Service) GetSolutionBackupResources(solutionID string, parameters conne
 
 // GetSolutionsPaginated retrieves a paginated list of solutions
 func (s *Service) GetSolutionBackupResourcesPaginated(solutionID string, parameters connection.APIRequestParameters) (*connection.Paginated[BackupResource], error) {
-	body, err := s.getSolutionBackupResourcesPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID == "" {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]BackupResource](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/backup-resources", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[BackupResource], error) {
 		return s.GetSolutionBackupResourcesPaginated(solutionID, p)
 	}), err
 }
 
-func (s *Service) getSolutionBackupResourcesPaginatedResponseBody(solutionID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]BackupResource], error) {
-	body := &connection.APIResponseBodyData[[]BackupResource]{}
-
-	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s/backup-resources", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
-}
-
 // GetSolutionBackupService retrieves the backup service for the specified solution
 func (s *Service) GetSolutionBackupService(solutionID string) (BackupService, error) {
-	body, err := s.getSolutionBackupServiceResponseBody(solutionID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSolutionBackupServiceResponseBody(solutionID string) (*connection.APIResponseBodyData[BackupService], error) {
-	body := &connection.APIResponseBodyData[BackupService]{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return BackupService{}, fmt.Errorf("invalid solution id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s/backup-service", solutionID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[BackupService](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/backup-service", solutionID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
+	return body.Data, err
 }
 
 // ResetSolutionBackupServiceCredentials resets the credentials for the solution backup service
 func (s *Service) ResetSolutionBackupServiceCredentials(solutionID string, req ResetBackupServiceCredentialsRequest) error {
-	_, err := s.resetSolutionBackupServiceCredentialsResponseBody(solutionID, req)
-
-	return err
-}
-
-func (s *Service) resetSolutionBackupServiceCredentialsResponseBody(solutionID string, req ResetBackupServiceCredentialsRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/draas/v1/solutions/%s/backup-service/reset-credentials", solutionID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/draas/v1/solutions/%s/backup-service/reset-credentials", solutionID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 }
 
 // GetSolutionFailoverPlans retrieves a collection of failover plans for specified solution
@@ -186,125 +78,47 @@ func (s *Service) GetSolutionFailoverPlans(solutionID string, parameters connect
 
 // GetSolutionsPaginated retrieves a paginated list of solution failover plans
 func (s *Service) GetSolutionFailoverPlansPaginated(solutionID string, parameters connection.APIRequestParameters) (*connection.Paginated[FailoverPlan], error) {
-	body, err := s.getSolutionFailoverPlansPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID == "" {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]FailoverPlan](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/failover-plans", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FailoverPlan], error) {
 		return s.GetSolutionFailoverPlansPaginated(solutionID, p)
 	}), err
 }
 
-func (s *Service) getSolutionFailoverPlansPaginatedResponseBody(solutionID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]FailoverPlan], error) {
-	body := &connection.APIResponseBodyData[[]FailoverPlan]{}
-
-	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s/failover-plans", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
-}
-
 // GetSolutionFailoverPlan retrieves a single solution failover plan by id
 func (s *Service) GetSolutionFailoverPlan(solutionID string, failoverPlanID string) (FailoverPlan, error) {
-	body, err := s.getSolutionFailoverPlanResponseBody(solutionID, failoverPlanID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSolutionFailoverPlanResponseBody(solutionID string, failoverPlanID string) (*connection.APIResponseBodyData[FailoverPlan], error) {
-	body := &connection.APIResponseBodyData[FailoverPlan]{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return FailoverPlan{}, fmt.Errorf("invalid solution id")
 	}
 	if failoverPlanID == "" {
-		return body, fmt.Errorf("invalid failover plan id")
+		return FailoverPlan{}, fmt.Errorf("invalid failover plan id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s/failover-plans/%s", solutionID, failoverPlanID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FailoverPlanNotFoundError{ID: failoverPlanID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[FailoverPlan](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/failover-plans/%s", solutionID, failoverPlanID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&FailoverPlanNotFoundError{ID: failoverPlanID}))
+	return body.Data, err
 }
 
 // StartSolutionFailoverPlan starts the specified failover plan
 func (s *Service) StartSolutionFailoverPlan(solutionID string, failoverPlanID string, req StartFailoverPlanRequest) error {
-	_, err := s.startSolutionFailoverPlanResponseBody(solutionID, failoverPlanID, req)
-
-	return err
-}
-
-func (s *Service) startSolutionFailoverPlanResponseBody(solutionID string, failoverPlanID string, req StartFailoverPlanRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
 	if failoverPlanID == "" {
-		return body, fmt.Errorf("invalid failover plan id")
+		return fmt.Errorf("invalid failover plan id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/draas/v1/solutions/%s/failover-plans/%s/start", solutionID, failoverPlanID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FailoverPlanNotFoundError{ID: failoverPlanID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/draas/v1/solutions/%s/failover-plans/%s/start", solutionID, failoverPlanID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&FailoverPlanNotFoundError{ID: failoverPlanID}))
 }
 
 // StopSolutionFailoverPlan stops the specified failover plan
 func (s *Service) StopSolutionFailoverPlan(solutionID string, failoverPlanID string) error {
-	_, err := s.stopSolutionFailoverPlanResponseBody(solutionID, failoverPlanID)
-
-	return err
-}
-
-func (s *Service) stopSolutionFailoverPlanResponseBody(solutionID string, failoverPlanID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
 	if failoverPlanID == "" {
-		return body, fmt.Errorf("invalid failover plan id")
+		return fmt.Errorf("invalid failover plan id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/draas/v1/solutions/%s/failover-plans/%s/stop", solutionID, failoverPlanID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FailoverPlanNotFoundError{ID: failoverPlanID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/draas/v1/solutions/%s/failover-plans/%s/stop", solutionID, failoverPlanID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&FailoverPlanNotFoundError{ID: failoverPlanID}))
 }
 
 // GetSolutionComputeResources retrieves a collection of compute resources for specified solution
@@ -316,63 +130,25 @@ func (s *Service) GetSolutionComputeResources(solutionID string, parameters conn
 
 // GetSolutionComputeResourcesPaginated retrieves a paginated list of solution compute resources
 func (s *Service) GetSolutionComputeResourcesPaginated(solutionID string, parameters connection.APIRequestParameters) (*connection.Paginated[ComputeResource], error) {
-	body, err := s.getSolutionComputeResourcesPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID == "" {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]ComputeResource](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/compute-resources", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ComputeResource], error) {
 		return s.GetSolutionComputeResourcesPaginated(solutionID, p)
 	}), err
 }
 
-func (s *Service) getSolutionComputeResourcesPaginatedResponseBody(solutionID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ComputeResource], error) {
-	body := &connection.APIResponseBodyData[[]ComputeResource]{}
-
-	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s/compute-resources", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
-}
-
 // GetSolutionComputeResource retrieves compute resources by id
 func (s *Service) GetSolutionComputeResource(solutionID string, computeResourceID string) (ComputeResource, error) {
-	body, err := s.getSolutionComputeResourceResponseBody(solutionID, computeResourceID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSolutionComputeResourceResponseBody(solutionID string, computeResourceID string) (*connection.APIResponseBodyData[ComputeResource], error) {
-	body := &connection.APIResponseBodyData[ComputeResource]{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return ComputeResource{}, fmt.Errorf("invalid solution id")
 	}
 	if computeResourceID == "" {
-		return body, fmt.Errorf("invalid compute resource id")
+		return ComputeResource{}, fmt.Errorf("invalid compute resource id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s/compute-resources/%s", solutionID, computeResourceID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ComputeResourceNotFoundError{ID: computeResourceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[ComputeResource](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/compute-resources/%s", solutionID, computeResourceID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ComputeResourceNotFoundError{ID: computeResourceID}))
+	return body.Data, err
 }
 
 // GetSolutionHardwarePlans retrieves a collection of hardware plans for specified solution
@@ -384,63 +160,25 @@ func (s *Service) GetSolutionHardwarePlans(solutionID string, parameters connect
 
 // GetSolutionHardwarePlansPaginated retrieves a paginated list of solution hardware plans
 func (s *Service) GetSolutionHardwarePlansPaginated(solutionID string, parameters connection.APIRequestParameters) (*connection.Paginated[HardwarePlan], error) {
-	body, err := s.getSolutionHardwarePlansPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID == "" {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]HardwarePlan](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/hardware-plans", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[HardwarePlan], error) {
 		return s.GetSolutionHardwarePlansPaginated(solutionID, p)
 	}), err
 }
 
-func (s *Service) getSolutionHardwarePlansPaginatedResponseBody(solutionID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]HardwarePlan], error) {
-	body := &connection.APIResponseBodyData[[]HardwarePlan]{}
-
-	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s/hardware-plans", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
-}
-
 // GetSolutionHardwarePlan retrieves hardware plans by id
 func (s *Service) GetSolutionHardwarePlan(solutionID string, hardwarePlanID string) (HardwarePlan, error) {
-	body, err := s.getSolutionHardwarePlanResponseBody(solutionID, hardwarePlanID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSolutionHardwarePlanResponseBody(solutionID string, hardwarePlanID string) (*connection.APIResponseBodyData[HardwarePlan], error) {
-	body := &connection.APIResponseBodyData[HardwarePlan]{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return HardwarePlan{}, fmt.Errorf("invalid solution id")
 	}
 	if hardwarePlanID == "" {
-		return body, fmt.Errorf("invalid hardware plan id")
+		return HardwarePlan{}, fmt.Errorf("invalid hardware plan id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s/hardware-plans/%s", solutionID, hardwarePlanID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HardwarePlanNotFoundError{ID: hardwarePlanID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[HardwarePlan](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/hardware-plans/%s", solutionID, hardwarePlanID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&HardwarePlanNotFoundError{ID: hardwarePlanID}))
+	return body.Data, err
 }
 
 // GetSolutionHardwarePlanReplicas retrieves a collection of hardware plans for specified solution
@@ -452,64 +190,25 @@ func (s *Service) GetSolutionHardwarePlanReplicas(solutionID string, hardwarePla
 
 // GetSolutionHardwarePlanReplicasPaginated retrieves a paginated list of solution hardware plans
 func (s *Service) GetSolutionHardwarePlanReplicasPaginated(solutionID string, hardwarePlanID string, parameters connection.APIRequestParameters) (*connection.Paginated[Replica], error) {
-	body, err := s.getSolutionHardwarePlanReplicasPaginatedResponseBody(solutionID, hardwarePlanID, parameters)
-
+	if solutionID == "" {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	if hardwarePlanID == "" {
+		return nil, fmt.Errorf("invalid hardware plan id")
+	}
+	body, err := connection.Get[[]Replica](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/hardware-plans/%s/replicas", solutionID, hardwarePlanID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Replica], error) {
 		return s.GetSolutionHardwarePlanReplicasPaginated(solutionID, hardwarePlanID, p)
 	}), err
 }
 
-func (s *Service) getSolutionHardwarePlanReplicasPaginatedResponseBody(solutionID string, hardwarePlanID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Replica], error) {
-	body := &connection.APIResponseBodyData[[]Replica]{}
-
-	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
-	}
-	if hardwarePlanID == "" {
-		return body, fmt.Errorf("invalid hardware plan id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/draas/v1/solutions/%s/hardware-plans/%s/replicas", solutionID, hardwarePlanID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
-}
-
 // UpdateSolutionReplicaIOPS updates a solution replica by ID
 func (s *Service) UpdateSolutionReplicaIOPS(solutionID string, replicaID string, req UpdateReplicaIOPSRequest) error {
-	_, err := s.updateSolutionReplicaResponseBody(solutionID, replicaID, req)
-
-	return err
-}
-
-func (s *Service) updateSolutionReplicaResponseBody(solutionID string, replicaID string, req UpdateReplicaIOPSRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID == "" {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
 	if replicaID == "" {
-		return body, fmt.Errorf("invalid replica id")
+		return fmt.Errorf("invalid replica id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/draas/v1/solutions/%s/replicas/%s/iops", solutionID, replicaID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ReplicaNotFoundError{ID: replicaID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/draas/v1/solutions/%s/replicas/%s/iops", solutionID, replicaID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ReplicaNotFoundError{ID: replicaID}))
 }

--- a/pkg/service/ecloud/service_activedirectory.go
+++ b/pkg/service/ecloud/service_activedirectory.go
@@ -13,45 +13,15 @@ func (s *Service) GetActiveDirectoryDomains(parameters connection.APIRequestPara
 
 // GetActiveDirectoryDomainsPaginated retrieves a paginated list of Active Directory Domains
 func (s *Service) GetActiveDirectoryDomainsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[ActiveDirectoryDomain], error) {
-	body, err := s.getActiveDirectoryDomainsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]ActiveDirectoryDomain](s.connection, "/ecloud/v1/active-directory/domains", parameters)
 	return connection.NewPaginated(body, parameters, s.GetActiveDirectoryDomainsPaginated), err
-}
-
-func (s *Service) getActiveDirectoryDomainsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ActiveDirectoryDomain], error) {
-	body := &connection.APIResponseBodyData[[]ActiveDirectoryDomain]{}
-
-	response, err := s.connection.Get("/ecloud/v1/active-directory/domains", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetActiveDirectoryDomain retrieves a single domain by ID
 func (s *Service) GetActiveDirectoryDomain(domainID int) (ActiveDirectoryDomain, error) {
-	body, err := s.getActiveDirectoryDomainResponseBody(domainID)
-
-	return body.Data, err
-}
-
-func (s *Service) getActiveDirectoryDomainResponseBody(domainID int) (*connection.APIResponseBodyData[ActiveDirectoryDomain], error) {
-	body := &connection.APIResponseBodyData[ActiveDirectoryDomain]{}
-
 	if domainID < 1 {
-		return body, fmt.Errorf("invalid domain id")
+		return ActiveDirectoryDomain{}, fmt.Errorf("invalid domain id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/active-directory/domains/%d", domainID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ActiveDirectoryDomainNotFoundError{ID: domainID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[ActiveDirectoryDomain](s.connection, fmt.Sprintf("/ecloud/v1/active-directory/domains/%d", domainID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ActiveDirectoryDomainNotFoundError{ID: domainID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_affinityrule.go
+++ b/pkg/service/ecloud/service_affinityrule.go
@@ -13,119 +13,39 @@ func (s *Service) GetAffinityRules(parameters connection.APIRequestParameters) (
 
 // GetAffinityRulesPaginated retrieves a paginated list of affinity rules
 func (s *Service) GetAffinityRulesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[AffinityRule], error) {
-	body, err := s.getAffinityRulesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]AffinityRule](s.connection, "/ecloud/v2/affinity-rules", parameters)
 	return connection.NewPaginated(body, parameters, s.GetAffinityRulesPaginated), err
-}
-
-func (s *Service) getAffinityRulesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]AffinityRule], error) {
-	body := &connection.APIResponseBodyData[[]AffinityRule]{}
-
-	response, err := s.connection.Get("/ecloud/v2/affinity-rules", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetAffinityRule retrieves a single AffinityRule by id
 func (s *Service) GetAffinityRule(affinityruleID string) (AffinityRule, error) {
-	body, err := s.getAffinityRuleResponseBody(affinityruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getAffinityRuleResponseBody(affinityruleID string) (*connection.APIResponseBodyData[AffinityRule], error) {
-	body := &connection.APIResponseBodyData[AffinityRule]{}
-
 	if affinityruleID == "" {
-		return body, fmt.Errorf("invalid affinity rule id")
+		return AffinityRule{}, fmt.Errorf("invalid affinity rule id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/affinity-rules/%s", affinityruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AffinityRuleNotFoundError{ID: affinityruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[AffinityRule](s.connection, fmt.Sprintf("/ecloud/v2/affinity-rules/%s", affinityruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&AffinityRuleNotFoundError{ID: affinityruleID}))
+	return body.Data, err
 }
 
 // CreateAffinityRule creates a new AffinityRule
 func (s *Service) CreateAffinityRule(req CreateAffinityRuleRequest) (TaskReference, error) {
-	body, err := s.createAffinityRuleResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/affinity-rules", &req)
 	return body.Data, err
-}
-
-func (s *Service) createAffinityRuleResponseBody(req CreateAffinityRuleRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/affinity-rules", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchAffinityRule patches a AffinityRule
 func (s *Service) PatchAffinityRule(affinityruleID string, req PatchAffinityRuleRequest) (TaskReference, error) {
-	body, err := s.patchAffinityRuleResponseBody(affinityruleID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchAffinityRuleResponseBody(affinityruleID string, req PatchAffinityRuleRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if affinityruleID == "" {
-		return body, fmt.Errorf("invalid affinity rule id")
+		return TaskReference{}, fmt.Errorf("invalid affinity rule id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/affinity-rules/%s", affinityruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AffinityRuleNotFoundError{ID: affinityruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/affinity-rules/%s", affinityruleID), &req, connection.NotFoundResponseHandler(&AffinityRuleNotFoundError{ID: affinityruleID}))
+	return body.Data, err
 }
 
 // DeleteAffinityRule deletes a AffinityRule
 func (s *Service) DeleteAffinityRule(affinityruleID string) (string, error) {
-	body, err := s.deleteAffinityRuleResponseBody(affinityruleID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteAffinityRuleResponseBody(affinityruleID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if affinityruleID == "" {
-		return body, fmt.Errorf("invalid affinity rule id")
+		return "", fmt.Errorf("invalid affinity rule id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/affinity-rules/%s", affinityruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AffinityRuleNotFoundError{ID: affinityruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/affinity-rules/%s", affinityruleID), nil, connection.NotFoundResponseHandler(&AffinityRuleNotFoundError{ID: affinityruleID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_affinityrulemember.go
+++ b/pkg/service/ecloud/service_affinityrulemember.go
@@ -16,7 +16,7 @@ func (s *Service) GetAffinityRuleMembers(affinityRuleID string, parameters conne
 
 // GetAffinityRuleMembersPaginated retrieves a paginated list of affinity rule members
 func (s *Service) GetAffinityRuleMembersPaginated(affinityRuleID string, parameters connection.APIRequestParameters) (*connection.Paginated[AffinityRuleMember], error) {
-	body, err := s.getAffinityRuleMembersPaginatedResponseBody(affinityRuleID, parameters)
+	body, err := connection.Get[[]AffinityRuleMember](s.connection, fmt.Sprintf("/ecloud/v2/affinity-rules/%s/members", affinityRuleID), parameters)
 	return connection.NewPaginated(
 		body,
 		parameters,
@@ -25,87 +25,26 @@ func (s *Service) GetAffinityRuleMembersPaginated(affinityRuleID string, paramet
 		}), err
 }
 
-func (s *Service) getAffinityRuleMembersPaginatedResponseBody(affinityRuleID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]AffinityRuleMember], error) {
-	body := &connection.APIResponseBodyData[[]AffinityRuleMember]{}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/affinity-rules/%s/members", affinityRuleID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
-}
-
 // GetAffinityRuleMember retrieves a single AffinityRuleMember by id
 func (s *Service) GetAffinityRuleMember(memberID string) (AffinityRuleMember, error) {
-	body, err := s.getAffinityRuleMemberResponseBody(memberID)
-
-	return body.Data, err
-}
-
-func (s *Service) getAffinityRuleMemberResponseBody(memberID string) (*connection.APIResponseBodyData[AffinityRuleMember], error) {
-	body := &connection.APIResponseBodyData[AffinityRuleMember]{}
-
 	if memberID == "" {
-		return body, fmt.Errorf("invalid affinity rule member id")
+		return AffinityRuleMember{}, fmt.Errorf("invalid affinity rule member id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/affinity-rule-members/%s", memberID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AffinityRuleMemberNotFoundError{ID: memberID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[AffinityRuleMember](s.connection, fmt.Sprintf("/ecloud/v2/affinity-rule-members/%s", memberID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&AffinityRuleMemberNotFoundError{ID: memberID}))
+	return body.Data, err
 }
 
 // CreateAffinityRuleMember creates a new AffinityRuleMember
 func (s *Service) CreateAffinityRuleMember(req CreateAffinityRuleMemberRequest) (TaskReference, error) {
-	body, err := s.createAffinityRuleMemberResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/affinity-rule-members", &req)
 	return body.Data, err
-}
-
-func (s *Service) createAffinityRuleMemberResponseBody(req CreateAffinityRuleMemberRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/affinity-rule-members", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // DeleteAffinityRuleMember deletes a AffinityRuleMember
 func (s *Service) DeleteAffinityRuleMember(memberID string) (string, error) {
-	body, err := s.deleteAffinityRuleMemberResponseBody(memberID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteAffinityRuleMemberResponseBody(memberID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if memberID == "" {
-		return body, fmt.Errorf("invalid affinity rule member id")
+		return "", fmt.Errorf("invalid affinity rule member id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/affinity-rule-members/%s", memberID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AffinityRuleMemberNotFoundError{ID: memberID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/affinity-rule-members/%s", memberID), nil, connection.NotFoundResponseHandler(&AffinityRuleMemberNotFoundError{ID: memberID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_appliance.go
+++ b/pkg/service/ecloud/service_appliance.go
@@ -13,47 +13,17 @@ func (s *Service) GetAppliances(parameters connection.APIRequestParameters) ([]A
 
 // GetAppliancesPaginated retrieves a paginated list of appliances
 func (s *Service) GetAppliancesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Appliance], error) {
-	body, err := s.getAppliancesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Appliance](s.connection, "/ecloud/v1/appliances", parameters)
 	return connection.NewPaginated(body, parameters, s.GetAppliancesPaginated), err
-}
-
-func (s *Service) getAppliancesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Appliance], error) {
-	body := &connection.APIResponseBodyData[[]Appliance]{}
-
-	response, err := s.connection.Get("/ecloud/v1/appliances", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetAppliance retrieves a single Appliance by ID
 func (s *Service) GetAppliance(applianceID string) (Appliance, error) {
-	body, err := s.getApplianceResponseBody(applianceID)
-
-	return body.Data, err
-}
-
-func (s *Service) getApplianceResponseBody(applianceID string) (*connection.APIResponseBodyData[Appliance], error) {
-	body := &connection.APIResponseBodyData[Appliance]{}
-
 	if applianceID == "" {
-		return body, fmt.Errorf("invalid appliance id")
+		return Appliance{}, fmt.Errorf("invalid appliance id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/appliances/%s", applianceID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ApplianceNotFoundError{ID: applianceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Appliance](s.connection, fmt.Sprintf("/ecloud/v1/appliances/%s", applianceID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ApplianceNotFoundError{ID: applianceID}))
+	return body.Data, err
 }
 
 // GetApplianceParameters retrieves a list of parameters
@@ -65,30 +35,11 @@ func (s *Service) GetApplianceParameters(applianceID string, parameters connecti
 
 // GetApplianceParametersPaginated retrieves a paginated list of domains
 func (s *Service) GetApplianceParametersPaginated(applianceID string, parameters connection.APIRequestParameters) (*connection.Paginated[ApplianceParameter], error) {
-	body, err := s.getApplianceParametersPaginatedResponseBody(applianceID, parameters)
-
+	if applianceID == "" {
+		return nil, fmt.Errorf("invalid appliance id")
+	}
+	body, err := connection.Get[[]ApplianceParameter](s.connection, fmt.Sprintf("/ecloud/v1/appliances/%s/parameters", applianceID), parameters, connection.NotFoundResponseHandler(&ApplianceNotFoundError{ID: applianceID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ApplianceParameter], error) {
 		return s.GetApplianceParametersPaginated(applianceID, p)
 	}), err
-}
-
-func (s *Service) getApplianceParametersPaginatedResponseBody(applianceID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ApplianceParameter], error) {
-	body := &connection.APIResponseBodyData[[]ApplianceParameter]{}
-
-	if applianceID == "" {
-		return body, fmt.Errorf("invalid appliance id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/appliances/%s/parameters", applianceID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ApplianceNotFoundError{ID: applianceID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_availabilityzone.go
+++ b/pkg/service/ecloud/service_availabilityzone.go
@@ -13,47 +13,17 @@ func (s *Service) GetAvailabilityZones(parameters connection.APIRequestParameter
 
 // GetAvailabilityZonesPaginated retrieves a paginated list of azs
 func (s *Service) GetAvailabilityZonesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[AvailabilityZone], error) {
-	body, err := s.getAvailabilityZonesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]AvailabilityZone](s.connection, "/ecloud/v2/availability-zones", parameters)
 	return connection.NewPaginated(body, parameters, s.GetAvailabilityZonesPaginated), err
-}
-
-func (s *Service) getAvailabilityZonesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]AvailabilityZone], error) {
-	body := &connection.APIResponseBodyData[[]AvailabilityZone]{}
-
-	response, err := s.connection.Get("/ecloud/v2/availability-zones", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetAvailabilityZone retrieves a single az by id
 func (s *Service) GetAvailabilityZone(azID string) (AvailabilityZone, error) {
-	body, err := s.getAvailabilityZoneResponseBody(azID)
-
-	return body.Data, err
-}
-
-func (s *Service) getAvailabilityZoneResponseBody(azID string) (*connection.APIResponseBodyData[AvailabilityZone], error) {
-	body := &connection.APIResponseBodyData[AvailabilityZone]{}
-
 	if azID == "" {
-		return body, fmt.Errorf("invalid az id")
+		return AvailabilityZone{}, fmt.Errorf("invalid az id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/availability-zones/%s", azID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AvailabilityZoneNotFoundError{ID: azID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[AvailabilityZone](s.connection, fmt.Sprintf("/ecloud/v2/availability-zones/%s", azID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&AvailabilityZoneNotFoundError{ID: azID}))
+	return body.Data, err
 }
 
 // GetAvailabilityZones retrieves a list of azs
@@ -65,30 +35,11 @@ func (s *Service) GetAvailabilityZoneIOPSTiers(azID string, parameters connectio
 
 // GetAvailabilityZonesPaginated retrieves a paginated list of azs
 func (s *Service) GetAvailabilityZoneIOPSTiersPaginated(azID string, parameters connection.APIRequestParameters) (*connection.Paginated[IOPSTier], error) {
-	body, err := s.getAvailabilityZoneIOPSTiersPaginatedResponseBody(azID, parameters)
-
+	if azID == "" {
+		return nil, fmt.Errorf("invalid az id")
+	}
+	body, err := connection.Get[[]IOPSTier](s.connection, fmt.Sprintf("/ecloud/v2/availability-zones/%s/iops", azID), parameters, connection.NotFoundResponseHandler(&AvailabilityZoneNotFoundError{ID: azID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[IOPSTier], error) {
 		return s.GetAvailabilityZoneIOPSTiersPaginated(azID, p)
 	}), err
-}
-
-func (s *Service) getAvailabilityZoneIOPSTiersPaginatedResponseBody(azID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]IOPSTier], error) {
-	body := &connection.APIResponseBodyData[[]IOPSTier]{}
-
-	if azID == "" {
-		return body, fmt.Errorf("invalid az id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/availability-zones/%s/iops", azID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AvailabilityZoneNotFoundError{ID: azID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_backupgateway.go
+++ b/pkg/service/ecloud/service_backupgateway.go
@@ -13,76 +13,49 @@ func (s *Service) GetBackupGateways(parameters connection.APIRequestParameters) 
 
 // GetBackupGatewaysPaginated retrieves a paginated list of backup gateways
 func (s *Service) GetBackupGatewaysPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[BackupGateway], error) {
-	body, err := s.getBackupGatewaysPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]BackupGateway](s.connection, "/ecloud/v2/backup-gateways", parameters)
 	return connection.NewPaginated(body, parameters, s.GetBackupGatewaysPaginated), err
-}
-
-func (s *Service) getBackupGatewaysPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]BackupGateway], error) {
-	return connection.Get[[]BackupGateway](s.connection, "/ecloud/v2/backup-gateways", parameters)
 }
 
 // GetBackupGateway retrieves a single backup gateway by ID
 func (s *Service) GetBackupGateway(gatewayID string) (BackupGateway, error) {
-	body, err := s.getBackupGatewayResponseBody(gatewayID)
-
-	return body.Data, err
-}
-
-func (s *Service) getBackupGatewayResponseBody(gatewayID string) (*connection.APIResponseBodyData[BackupGateway], error) {
 	if gatewayID == "" {
-		return &connection.APIResponseBodyData[BackupGateway]{}, fmt.Errorf("invalid backup gateway id")
+		return BackupGateway{}, fmt.Errorf("invalid backup gateway id")
 	}
-
-	return connection.Get[BackupGateway](s.connection, fmt.Sprintf("/ecloud/v2/backup-gateways/%s", gatewayID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&BackupGatewayNotFoundError{ID: gatewayID}))
+	body, err := connection.Get[BackupGateway](s.connection, fmt.Sprintf("/ecloud/v2/backup-gateways/%s", gatewayID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&BackupGatewayNotFoundError{ID: gatewayID}))
+	return body.Data, err
 }
 
 // CreateBackupGateway creates a new backup gateway
 func (s *Service) CreateBackupGateway(req CreateBackupGatewayRequest) (TaskReference, error) {
-	body, err := s.createBackupGatewayResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/backup-gateways", &req)
 	return body.Data, err
-}
-
-func (s *Service) createBackupGatewayResponseBody(req CreateBackupGatewayRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	return connection.Post[TaskReference](s.connection, "/ecloud/v2/backup-gateways", &req)
 }
 
 // PatchBackupGateway patches a backup gateway
 func (s *Service) PatchBackupGateway(gatewayID string, req PatchBackupGatewayRequest) (TaskReference, error) {
-	body, err := s.patchBackupGatewayResponseBody(gatewayID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchBackupGatewayResponseBody(gatewayID string, req PatchBackupGatewayRequest) (*connection.APIResponseBodyData[TaskReference], error) {
 	if gatewayID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid gateway id")
+		return TaskReference{}, fmt.Errorf("invalid gateway id")
 	}
-
-	return connection.Patch[TaskReference](
+	body, err := connection.Patch[TaskReference](
 		s.connection,
 		fmt.Sprintf("/ecloud/v2/backup-gateways/%s", gatewayID),
 		&req,
 		connection.NotFoundResponseHandler(&BackupGatewayNotFoundError{ID: gatewayID}),
 	)
+	return body.Data, err
 }
 
 // DeleteBackupGateway deletes a backup gateway
 func (s *Service) DeleteBackupGateway(gatewayID string) (string, error) {
-	body, err := s.deleteBackupGatewayResponseBody(gatewayID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteBackupGatewayResponseBody(gatewayID string) (*connection.APIResponseBodyData[TaskReference], error) {
 	if gatewayID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid gateway id")
+		return "", fmt.Errorf("invalid gateway id")
 	}
-
-	return connection.Delete[TaskReference](
+	body, err := connection.Delete[TaskReference](
 		s.connection,
 		fmt.Sprintf("/ecloud/v2/backup-gateways/%s", gatewayID),
 		nil,
 		connection.NotFoundResponseHandler(&BackupGatewayNotFoundError{ID: gatewayID}),
 	)
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_backupgateway_specs.go
+++ b/pkg/service/ecloud/service_backupgateway_specs.go
@@ -13,30 +13,20 @@ func (s *Service) GetBackupGatewaySpecifications(parameters connection.APIReques
 
 // GetBackupGatewaySpecificationsPaginated retrieves a paginated list of Backup gateway specifications
 func (s *Service) GetBackupGatewaySpecificationsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[BackupGatewaySpecification], error) {
-	body, err := s.getBackupGatewaySpecificationsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]BackupGatewaySpecification](s.connection, "/ecloud/v2/backup-gateway-specs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetBackupGatewaySpecificationsPaginated), err
-}
-
-func (s *Service) getBackupGatewaySpecificationsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]BackupGatewaySpecification], error) {
-	return connection.Get[[]BackupGatewaySpecification](s.connection, "/ecloud/v2/backup-gateway-specs", parameters)
 }
 
 // GetBackupGatewaySpecification retrieves a single Backup gateway specification by ID
 func (s *Service) GetBackupGatewaySpecification(specificationID string) (BackupGatewaySpecification, error) {
-	body, err := s.getBackupGatewaySpecificationResponseBody(specificationID)
-
-	return body.Data, err
-}
-
-func (s *Service) getBackupGatewaySpecificationResponseBody(specificationID string) (*connection.APIResponseBodyData[BackupGatewaySpecification], error) {
 	if specificationID == "" {
-		return &connection.APIResponseBodyData[BackupGatewaySpecification]{}, fmt.Errorf("invalid backup gateway specification id")
+		return BackupGatewaySpecification{}, fmt.Errorf("invalid backup gateway specification id")
 	}
-
-	return connection.Get[BackupGatewaySpecification](
+	body, err := connection.Get[BackupGatewaySpecification](
 		s.connection,
 		fmt.Sprintf("/ecloud/v2/backup-gateway-specs/%s", specificationID),
 		connection.APIRequestParameters{},
 		connection.NotFoundResponseHandler(&BackupGatewaySpecificationNotFoundError{ID: specificationID}),
 	)
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_billingmetric.go
+++ b/pkg/service/ecloud/service_billingmetric.go
@@ -13,45 +13,15 @@ func (s *Service) GetBillingMetrics(parameters connection.APIRequestParameters) 
 
 // GetBillingMetricsPaginated retrieves a paginated list of billing metrics
 func (s *Service) GetBillingMetricsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[BillingMetric], error) {
-	body, err := s.getBillingMetricsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]BillingMetric](s.connection, "/ecloud/v2/billing-metrics", parameters)
 	return connection.NewPaginated(body, parameters, s.GetBillingMetricsPaginated), err
-}
-
-func (s *Service) getBillingMetricsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]BillingMetric], error) {
-	body := &connection.APIResponseBodyData[[]BillingMetric]{}
-
-	response, err := s.connection.Get("/ecloud/v2/billing-metrics", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetBillingMetric retrieves a single billing metrics by id
 func (s *Service) GetBillingMetric(metricID string) (BillingMetric, error) {
-	body, err := s.getBillingMetricResponseBody(metricID)
-
-	return body.Data, err
-}
-
-func (s *Service) getBillingMetricResponseBody(metricID string) (*connection.APIResponseBodyData[BillingMetric], error) {
-	body := &connection.APIResponseBodyData[BillingMetric]{}
-
 	if metricID == "" {
-		return body, fmt.Errorf("invalid metric id")
+		return BillingMetric{}, fmt.Errorf("invalid metric id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/billing-metrics/%s", metricID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &BillingMetricNotFoundError{ID: metricID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[BillingMetric](s.connection, fmt.Sprintf("/ecloud/v2/billing-metrics/%s", metricID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&BillingMetricNotFoundError{ID: metricID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_credit.go
+++ b/pkg/service/ecloud/service_credit.go
@@ -7,18 +7,6 @@ import (
 
 // GetCredits retrieves a list of credits
 func (s *Service) GetCredits(parameters connection.APIRequestParameters) ([]account.Credit, error) {
-	body, err := s.getCreditsResponseBody(parameters)
-
+	body, err := connection.Get[[]account.Credit](s.connection, "/ecloud/v1/credits", parameters)
 	return body.Data, err
-}
-
-func (s *Service) getCreditsResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]account.Credit], error) {
-	body := &connection.APIResponseBodyData[[]account.Credit]{}
-
-	response, err := s.connection.Get("/ecloud/v1/credits", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/ecloud/service_datastore.go
+++ b/pkg/service/ecloud/service_datastore.go
@@ -13,45 +13,15 @@ func (s *Service) GetDatastores(parameters connection.APIRequestParameters) ([]D
 
 // GetDatastoresPaginated retrieves a paginated list of datastores
 func (s *Service) GetDatastoresPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Datastore], error) {
-	body, err := s.getDatastoresPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Datastore](s.connection, "/ecloud/v1/datastores", parameters)
 	return connection.NewPaginated(body, parameters, s.GetDatastoresPaginated), err
-}
-
-func (s *Service) getDatastoresPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Datastore], error) {
-	body := &connection.APIResponseBodyData[[]Datastore]{}
-
-	response, err := s.connection.Get("/ecloud/v1/datastores", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetDatastore retrieves a single datastore by ID
 func (s *Service) GetDatastore(datastoreID int) (Datastore, error) {
-	body, err := s.getDatastoreResponseBody(datastoreID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDatastoreResponseBody(datastoreID int) (*connection.APIResponseBodyData[Datastore], error) {
-	body := &connection.APIResponseBodyData[Datastore]{}
-
 	if datastoreID < 1 {
-		return body, fmt.Errorf("invalid datastore id")
+		return Datastore{}, fmt.Errorf("invalid datastore id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/datastores/%d", datastoreID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DatastoreNotFoundError{ID: datastoreID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Datastore](s.connection, fmt.Sprintf("/ecloud/v1/datastores/%d", datastoreID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DatastoreNotFoundError{ID: datastoreID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_dhcp.go
+++ b/pkg/service/ecloud/service_dhcp.go
@@ -13,47 +13,17 @@ func (s *Service) GetDHCPs(parameters connection.APIRequestParameters) ([]DHCP, 
 
 // GetDHCPsPaginated retrieves a paginated list of dhcps
 func (s *Service) GetDHCPsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[DHCP], error) {
-	body, err := s.getDHCPsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]DHCP](s.connection, "/ecloud/v2/dhcps", parameters)
 	return connection.NewPaginated(body, parameters, s.GetDHCPsPaginated), err
-}
-
-func (s *Service) getDHCPsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]DHCP], error) {
-	body := &connection.APIResponseBodyData[[]DHCP]{}
-
-	response, err := s.connection.Get("/ecloud/v2/dhcps", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetDHCP retrieves a single dhcp by id
 func (s *Service) GetDHCP(dhcpID string) (DHCP, error) {
-	body, err := s.getDHCPResponseBody(dhcpID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDHCPResponseBody(dhcpID string) (*connection.APIResponseBodyData[DHCP], error) {
-	body := &connection.APIResponseBodyData[DHCP]{}
-
 	if dhcpID == "" {
-		return body, fmt.Errorf("invalid dhcp id")
+		return DHCP{}, fmt.Errorf("invalid dhcp id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/dhcps/%s", dhcpID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DHCPNotFoundError{ID: dhcpID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[DHCP](s.connection, fmt.Sprintf("/ecloud/v2/dhcps/%s", dhcpID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DHCPNotFoundError{ID: dhcpID}))
+	return body.Data, err
 }
 
 // GetDHCPTasks retrieves a list of DHCP tasks
@@ -65,29 +35,11 @@ func (s *Service) GetDHCPTasks(dhcpID string, parameters connection.APIRequestPa
 
 // GetDHCPTasksPaginated retrieves a paginated list of DHCP tasks
 func (s *Service) GetDHCPTasksPaginated(dhcpID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getDHCPTasksPaginatedResponseBody(dhcpID, parameters)
+	if dhcpID == "" {
+		return nil, fmt.Errorf("invalid dhcp id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/dhcps/%s/tasks", dhcpID), parameters, connection.NotFoundResponseHandler(&DHCPNotFoundError{ID: dhcpID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetDHCPTasksPaginated(dhcpID, p)
 	}), err
-}
-
-func (s *Service) getDHCPTasksPaginatedResponseBody(dhcpID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if dhcpID == "" {
-		return body, fmt.Errorf("invalid dhcp id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/dhcps/%s/tasks", dhcpID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DHCPNotFoundError{ID: dhcpID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_discountplan.go
+++ b/pkg/service/ecloud/service_discountplan.go
@@ -13,101 +13,31 @@ func (s *Service) GetDiscountPlans(parameters connection.APIRequestParameters) (
 
 // GetDiscountPlansPaginated retrieves a paginated list of discount plans
 func (s *Service) GetDiscountPlansPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[DiscountPlan], error) {
-	body, err := s.getDiscountPlansPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]DiscountPlan](s.connection, "/ecloud/v2/discount-plans", parameters)
 	return connection.NewPaginated(body, parameters, s.GetDiscountPlansPaginated), err
-}
-
-func (s *Service) getDiscountPlansPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]DiscountPlan], error) {
-	body := &connection.APIResponseBodyData[[]DiscountPlan]{}
-
-	response, err := s.connection.Get("/ecloud/v2/discount-plans", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetDiscountPlan retrieves a single discount plan by id
 func (s *Service) GetDiscountPlan(discID string) (DiscountPlan, error) {
-	body, err := s.getDiscountPlanResponseBody(discID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDiscountPlanResponseBody(discID string) (*connection.APIResponseBodyData[DiscountPlan], error) {
-	body := &connection.APIResponseBodyData[DiscountPlan]{}
-
 	if discID == "" {
-		return body, fmt.Errorf("invalid discount plan id")
+		return DiscountPlan{}, fmt.Errorf("invalid discount plan id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/discount-plans/%s", discID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DiscountPlanNotFoundError{ID: discID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[DiscountPlan](s.connection, fmt.Sprintf("/ecloud/v2/discount-plans/%s", discID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DiscountPlanNotFoundError{ID: discID}))
+	return body.Data, err
 }
 
 // ApproveDiscountPlan approves a floating IP to a resource
 func (s *Service) ApproveDiscountPlan(discID string) error {
-	_, err := s.approveDiscountPlanResponseBody(discID)
-
-	return err
-}
-
-func (s *Service) approveDiscountPlanResponseBody(discID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if discID == "" {
-		return body, fmt.Errorf("invalid floating IP id")
+		return fmt.Errorf("invalid floating IP id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/discount-plans/%s/approve", discID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DiscountPlanNotFoundError{ID: discID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v2/discount-plans/%s/approve", discID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DiscountPlanNotFoundError{ID: discID}))
 }
 
 // RejectDiscountPlan rejects a floating IP from a resource
 func (s *Service) RejectDiscountPlan(discID string) error {
-	_, err := s.rejectDiscountPlanResponseBody(discID)
-
-	return err
-}
-
-func (s *Service) rejectDiscountPlanResponseBody(discID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if discID == "" {
-		return body, fmt.Errorf("invalid floating IP id")
+		return fmt.Errorf("invalid floating IP id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/discount-plans/%s/reject", discID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DiscountPlanNotFoundError{ID: discID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v2/discount-plans/%s/reject", discID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DiscountPlanNotFoundError{ID: discID}))
 }

--- a/pkg/service/ecloud/service_firewall.go
+++ b/pkg/service/ecloud/service_firewall.go
@@ -13,73 +13,24 @@ func (s *Service) GetFirewalls(parameters connection.APIRequestParameters) ([]Fi
 
 // GetFirewallsPaginated retrieves a paginated list of firewalls
 func (s *Service) GetFirewallsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Firewall], error) {
-	body, err := s.getFirewallsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Firewall](s.connection, "/ecloud/v1/firewalls", parameters)
 	return connection.NewPaginated(body, parameters, s.GetFirewallsPaginated), err
-}
-
-func (s *Service) getFirewallsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Firewall], error) {
-	body := &connection.APIResponseBodyData[[]Firewall]{}
-
-	response, err := s.connection.Get("/ecloud/v1/firewalls", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetFirewall retrieves a single firewall by ID
 func (s *Service) GetFirewall(firewallID int) (Firewall, error) {
-	body, err := s.getFirewallResponseBody(firewallID)
-
-	return body.Data, err
-}
-
-func (s *Service) getFirewallResponseBody(firewallID int) (*connection.APIResponseBodyData[Firewall], error) {
-	body := &connection.APIResponseBodyData[Firewall]{}
-
 	if firewallID < 1 {
-		return body, fmt.Errorf("invalid firewall id")
+		return Firewall{}, fmt.Errorf("invalid firewall id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/firewalls/%d", firewallID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallNotFoundError{ID: firewallID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Firewall](s.connection, fmt.Sprintf("/ecloud/v1/firewalls/%d", firewallID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&FirewallNotFoundError{ID: firewallID}))
+	return body.Data, err
 }
 
 // GetFirewallConfig retrieves a single firewall config by ID
 func (s *Service) GetFirewallConfig(firewallID int) (FirewallConfig, error) {
-	body, err := s.getFirewallConfigResponseBody(firewallID)
-
-	return body.Data, err
-}
-
-func (s *Service) getFirewallConfigResponseBody(firewallID int) (*connection.APIResponseBodyData[FirewallConfig], error) {
-	body := &connection.APIResponseBodyData[FirewallConfig]{}
-
 	if firewallID < 1 {
-		return body, fmt.Errorf("invalid firewall id")
+		return FirewallConfig{}, fmt.Errorf("invalid firewall id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/firewalls/%d/config", firewallID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallNotFoundError{ID: firewallID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[FirewallConfig](s.connection, fmt.Sprintf("/ecloud/v1/firewalls/%d/config", firewallID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&FirewallNotFoundError{ID: firewallID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_firewallpolicy.go
+++ b/pkg/service/ecloud/service_firewallpolicy.go
@@ -13,121 +13,41 @@ func (s *Service) GetFirewallPolicies(parameters connection.APIRequestParameters
 
 // GetFirewallPoliciesPaginated retrieves a paginated list of firewall policies
 func (s *Service) GetFirewallPoliciesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[FirewallPolicy], error) {
-	body, err := s.getFirewallPoliciesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]FirewallPolicy](s.connection, "/ecloud/v2/firewall-policies", parameters)
 	return connection.NewPaginated(body, parameters, s.GetFirewallPoliciesPaginated), err
-}
-
-func (s *Service) getFirewallPoliciesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]FirewallPolicy], error) {
-	body := &connection.APIResponseBodyData[[]FirewallPolicy]{}
-
-	response, err := s.connection.Get("/ecloud/v2/firewall-policies", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetFirewallPolicy retrieves a single firewall policy by id
 func (s *Service) GetFirewallPolicy(policyID string) (FirewallPolicy, error) {
-	body, err := s.getFirewallPolicyResponseBody(policyID)
-
-	return body.Data, err
-}
-
-func (s *Service) getFirewallPolicyResponseBody(policyID string) (*connection.APIResponseBodyData[FirewallPolicy], error) {
-	body := &connection.APIResponseBodyData[FirewallPolicy]{}
-
 	if policyID == "" {
-		return body, fmt.Errorf("invalid firewall policy id")
+		return FirewallPolicy{}, fmt.Errorf("invalid firewall policy id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/firewall-policies/%s", policyID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[FirewallPolicy](s.connection, fmt.Sprintf("/ecloud/v2/firewall-policies/%s", policyID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&FirewallPolicyNotFoundError{ID: policyID}))
+	return body.Data, err
 }
 
 // CreateFirewallPolicy creates a new FirewallPolicy
 func (s *Service) CreateFirewallPolicy(req CreateFirewallPolicyRequest) (TaskReference, error) {
-	body, err := s.createFirewallPolicyResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/firewall-policies", &req)
 	return body.Data, err
-}
-
-func (s *Service) createFirewallPolicyResponseBody(req CreateFirewallPolicyRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/firewall-policies", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchFirewallPolicy patches a FirewallPolicy
 func (s *Service) PatchFirewallPolicy(policyID string, req PatchFirewallPolicyRequest) (TaskReference, error) {
-	body, err := s.patchFirewallPolicyResponseBody(policyID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchFirewallPolicyResponseBody(policyID string, req PatchFirewallPolicyRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if policyID == "" {
-		return body, fmt.Errorf("invalid policy id")
+		return TaskReference{}, fmt.Errorf("invalid policy id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/firewall-policies/%s", policyID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/firewall-policies/%s", policyID), &req, connection.NotFoundResponseHandler(&FirewallPolicyNotFoundError{ID: policyID}))
+	return body.Data, err
 }
 
 // DeleteFirewallPolicy deletes a FirewallPolicy
 func (s *Service) DeleteFirewallPolicy(policyID string) (string, error) {
-	body, err := s.deleteFirewallPolicyResponseBody(policyID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteFirewallPolicyResponseBody(policyID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if policyID == "" {
-		return body, fmt.Errorf("invalid policy id")
+		return "", fmt.Errorf("invalid policy id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/firewall-policies/%s", policyID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/firewall-policies/%s", policyID), nil, connection.NotFoundResponseHandler(&FirewallPolicyNotFoundError{ID: policyID}))
+	return body.Data.TaskID, err
 }
 
 // GetFirewallPolicyFirewallRules retrieves a list of firewall policy rules
@@ -139,32 +59,13 @@ func (s *Service) GetFirewallPolicyFirewallRules(policyID string, parameters con
 
 // GetFirewallPolicyFirewallRulesPaginated retrieves a paginated list of firewall policy FirewallRules
 func (s *Service) GetFirewallPolicyFirewallRulesPaginated(policyID string, parameters connection.APIRequestParameters) (*connection.Paginated[FirewallRule], error) {
-	body, err := s.getFirewallPolicyFirewallRulesPaginatedResponseBody(policyID, parameters)
-
+	if policyID == "" {
+		return nil, fmt.Errorf("invalid firewall policy id")
+	}
+	body, err := connection.Get[[]FirewallRule](s.connection, fmt.Sprintf("/ecloud/v2/firewall-policies/%s/firewall-rules", policyID), parameters, connection.NotFoundResponseHandler(&FirewallPolicyNotFoundError{ID: policyID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FirewallRule], error) {
 		return s.GetFirewallPolicyFirewallRulesPaginated(policyID, p)
 	}), err
-}
-
-func (s *Service) getFirewallPolicyFirewallRulesPaginatedResponseBody(policyID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]FirewallRule], error) {
-	body := &connection.APIResponseBodyData[[]FirewallRule]{}
-
-	if policyID == "" {
-		return body, fmt.Errorf("invalid firewall policy id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/firewall-policies/%s/firewall-rules", policyID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
 }
 
 // GetFirewallPolicyTasks retrieves a list of FirewallPolicy tasks
@@ -176,30 +77,11 @@ func (s *Service) GetFirewallPolicyTasks(policyID string, parameters connection.
 
 // GetFirewallPolicyTasksPaginated retrieves a paginated list of FirewallPolicy tasks
 func (s *Service) GetFirewallPolicyTasksPaginated(policyID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getFirewallPolicyTasksPaginatedResponseBody(policyID, parameters)
-
+	if policyID == "" {
+		return nil, fmt.Errorf("invalid firewall policy id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/firewall-policies/%s/tasks", policyID), parameters, connection.NotFoundResponseHandler(&FirewallPolicyNotFoundError{ID: policyID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetFirewallPolicyTasksPaginated(policyID, p)
 	}), err
-}
-
-func (s *Service) getFirewallPolicyTasksPaginatedResponseBody(policyID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if policyID == "" {
-		return body, fmt.Errorf("invalid firewall policy id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/firewall-policies/%s/tasks", policyID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_firewallrule.go
+++ b/pkg/service/ecloud/service_firewallrule.go
@@ -13,121 +13,41 @@ func (s *Service) GetFirewallRules(parameters connection.APIRequestParameters) (
 
 // GetFirewallRulesPaginated retrieves a paginated list of firewall rules
 func (s *Service) GetFirewallRulesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[FirewallRule], error) {
-	body, err := s.getFirewallRulesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]FirewallRule](s.connection, "/ecloud/v2/firewall-rules", parameters)
 	return connection.NewPaginated(body, parameters, s.GetFirewallRulesPaginated), err
-}
-
-func (s *Service) getFirewallRulesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]FirewallRule], error) {
-	body := &connection.APIResponseBodyData[[]FirewallRule]{}
-
-	response, err := s.connection.Get("/ecloud/v2/firewall-rules", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetFirewallRule retrieves a single rule by id
 func (s *Service) GetFirewallRule(ruleID string) (FirewallRule, error) {
-	body, err := s.getFirewallRuleResponseBody(ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getFirewallRuleResponseBody(ruleID string) (*connection.APIResponseBodyData[FirewallRule], error) {
-	body := &connection.APIResponseBodyData[FirewallRule]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid firewall rule id")
+		return FirewallRule{}, fmt.Errorf("invalid firewall rule id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/firewall-rules/%s", ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[FirewallRule](s.connection, fmt.Sprintf("/ecloud/v2/firewall-rules/%s", ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&FirewallRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // CreateFirewallRule creates a new FirewallRule
 func (s *Service) CreateFirewallRule(req CreateFirewallRuleRequest) (TaskReference, error) {
-	body, err := s.createFirewallRuleResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/firewall-rules", &req)
 	return body.Data, err
-}
-
-func (s *Service) createFirewallRuleResponseBody(req CreateFirewallRuleRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/firewall-rules", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchFirewallRule patches a FirewallRule
 func (s *Service) PatchFirewallRule(ruleID string, req PatchFirewallRuleRequest) (TaskReference, error) {
-	body, err := s.patchFirewallRuleResponseBody(ruleID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchFirewallRuleResponseBody(ruleID string, req PatchFirewallRuleRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid firewall rule id")
+		return TaskReference{}, fmt.Errorf("invalid firewall rule id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/firewall-rules/%s", ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/firewall-rules/%s", ruleID), &req, connection.NotFoundResponseHandler(&FirewallRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // DeleteFirewallRule deletes a FirewallRule
 func (s *Service) DeleteFirewallRule(ruleID string) (string, error) {
-	body, err := s.deleteFirewallRuleResponseBody(ruleID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteFirewallRuleResponseBody(ruleID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid firewall rule id")
+		return "", fmt.Errorf("invalid firewall rule id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/firewall-rules/%s", ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/firewall-rules/%s", ruleID), nil, connection.NotFoundResponseHandler(&FirewallRuleNotFoundError{ID: ruleID}))
+	return body.Data.TaskID, err
 }
 
 // GetFirewallRuleFirewallRulePorts retrieves a list of firewall rule ports
@@ -139,20 +59,8 @@ func (s *Service) GetFirewallRuleFirewallRulePorts(firewallRuleID string, parame
 
 // GetFirewallRuleFirewallRulePortsPaginated retrieves a paginated list of firewall rule ports
 func (s *Service) GetFirewallRuleFirewallRulePortsPaginated(firewallRuleID string, parameters connection.APIRequestParameters) (*connection.Paginated[FirewallRulePort], error) {
-	body, err := s.getFirewallRuleFirewallRulePortsPaginatedResponseBody(firewallRuleID, parameters)
-
+	body, err := connection.Get[[]FirewallRulePort](s.connection, fmt.Sprintf("/ecloud/v2/firewall-rules/%s/ports", firewallRuleID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FirewallRulePort], error) {
 		return s.GetFirewallRuleFirewallRulePortsPaginated(firewallRuleID, p)
 	}), err
-}
-
-func (s *Service) getFirewallRuleFirewallRulePortsPaginatedResponseBody(firewallRuleID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]FirewallRulePort], error) {
-	body := &connection.APIResponseBodyData[[]FirewallRulePort]{}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/firewall-rules/%s/ports", firewallRuleID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/ecloud/service_firewallruleport.go
+++ b/pkg/service/ecloud/service_firewallruleport.go
@@ -13,119 +13,39 @@ func (s *Service) GetFirewallRulePorts(parameters connection.APIRequestParameter
 
 // GetFirewallRulePortsPaginated retrieves a paginated list of firewall rules
 func (s *Service) GetFirewallRulePortsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[FirewallRulePort], error) {
-	body, err := s.getFirewallRulePortsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]FirewallRulePort](s.connection, "/ecloud/v2/firewall-rule-ports", parameters)
 	return connection.NewPaginated(body, parameters, s.GetFirewallRulePortsPaginated), err
-}
-
-func (s *Service) getFirewallRulePortsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]FirewallRulePort], error) {
-	body := &connection.APIResponseBodyData[[]FirewallRulePort]{}
-
-	response, err := s.connection.Get("/ecloud/v2/firewall-rule-ports", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetFirewallRulePort retrieves a single rule by id
 func (s *Service) GetFirewallRulePort(ruleID string) (FirewallRulePort, error) {
-	body, err := s.getFirewallRulePortResponseBody(ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getFirewallRulePortResponseBody(ruleID string) (*connection.APIResponseBodyData[FirewallRulePort], error) {
-	body := &connection.APIResponseBodyData[FirewallRulePort]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid firewall rule id")
+		return FirewallRulePort{}, fmt.Errorf("invalid firewall rule id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/firewall-rule-ports/%s", ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallRulePortNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[FirewallRulePort](s.connection, fmt.Sprintf("/ecloud/v2/firewall-rule-ports/%s", ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&FirewallRulePortNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // CreateFirewallRulePort creates a new FirewallRulePort
 func (s *Service) CreateFirewallRulePort(req CreateFirewallRulePortRequest) (TaskReference, error) {
-	body, err := s.createFirewallRulePortResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/firewall-rule-ports", &req)
 	return body.Data, err
-}
-
-func (s *Service) createFirewallRulePortResponseBody(req CreateFirewallRulePortRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/firewall-rule-ports", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchFirewallRulePort patches a FirewallRulePort
 func (s *Service) PatchFirewallRulePort(ruleID string, req PatchFirewallRulePortRequest) (TaskReference, error) {
-	body, err := s.patchFirewallRulePortResponseBody(ruleID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchFirewallRulePortResponseBody(ruleID string, req PatchFirewallRulePortRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid firewall rule id")
+		return TaskReference{}, fmt.Errorf("invalid firewall rule id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/firewall-rule-ports/%s", ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallRulePortNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/firewall-rule-ports/%s", ruleID), &req, connection.NotFoundResponseHandler(&FirewallRulePortNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // DeleteFirewallRulePort deletes a FirewallRulePort
 func (s *Service) DeleteFirewallRulePort(ruleID string) (string, error) {
-	body, err := s.deleteFirewallRulePortResponseBody(ruleID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteFirewallRulePortResponseBody(ruleID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid firewall rule id")
+		return "", fmt.Errorf("invalid firewall rule id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/firewall-rule-ports/%s", ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FirewallRulePortNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/firewall-rule-ports/%s", ruleID), nil, connection.NotFoundResponseHandler(&FirewallRulePortNotFoundError{ID: ruleID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_floatingip.go
+++ b/pkg/service/ecloud/service_floatingip.go
@@ -13,177 +13,59 @@ func (s *Service) GetFloatingIPs(parameters connection.APIRequestParameters) ([]
 
 // GetFloatingIPsPaginated retrieves a paginated list of floating ips
 func (s *Service) GetFloatingIPsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[FloatingIP], error) {
-	body, err := s.getFloatingIPsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]FloatingIP](s.connection, "/ecloud/v2/floating-ips", parameters)
 	return connection.NewPaginated(body, parameters, s.GetFloatingIPsPaginated), err
-}
-
-func (s *Service) getFloatingIPsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]FloatingIP], error) {
-	body := &connection.APIResponseBodyData[[]FloatingIP]{}
-
-	response, err := s.connection.Get("/ecloud/v2/floating-ips", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetFloatingIP retrieves a single floating ip by id
 func (s *Service) GetFloatingIP(fipID string) (FloatingIP, error) {
-	body, err := s.getFloatingIPResponseBody(fipID)
-
-	return body.Data, err
-}
-
-func (s *Service) getFloatingIPResponseBody(fipID string) (*connection.APIResponseBodyData[FloatingIP], error) {
-	body := &connection.APIResponseBodyData[FloatingIP]{}
-
 	if fipID == "" {
-		return body, fmt.Errorf("invalid floating ip id")
+		return FloatingIP{}, fmt.Errorf("invalid floating ip id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/floating-ips/%s", fipID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FloatingIPNotFoundError{ID: fipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[FloatingIP](s.connection, fmt.Sprintf("/ecloud/v2/floating-ips/%s", fipID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&FloatingIPNotFoundError{ID: fipID}))
+	return body.Data, err
 }
 
 // CreateFloatingIP creates a new FloatingIP
 func (s *Service) CreateFloatingIP(req CreateFloatingIPRequest) (TaskReference, error) {
-	body, err := s.createFloatingIPResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/floating-ips", &req)
 	return body.Data, err
-}
-
-func (s *Service) createFloatingIPResponseBody(req CreateFloatingIPRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/floating-ips", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchFloatingIP patches a floating IP
 func (s *Service) PatchFloatingIP(fipID string, req PatchFloatingIPRequest) (TaskReference, error) {
-	body, err := s.patchFloatingIPResponseBody(fipID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchFloatingIPResponseBody(fipID string, req PatchFloatingIPRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if fipID == "" {
-		return body, fmt.Errorf("invalid floating IP id")
+		return TaskReference{}, fmt.Errorf("invalid floating IP id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/floating-ips/%s", fipID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FloatingIPNotFoundError{ID: fipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/floating-ips/%s", fipID), &req, connection.NotFoundResponseHandler(&FloatingIPNotFoundError{ID: fipID}))
+	return body.Data, err
 }
 
 // DeleteFloatingIP deletes a floating IP
 func (s *Service) DeleteFloatingIP(fipID string) (string, error) {
-	body, err := s.deleteFloatingIPResponseBody(fipID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteFloatingIPResponseBody(fipID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if fipID == "" {
-		return body, fmt.Errorf("invalid floating IP id")
+		return "", fmt.Errorf("invalid floating IP id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/floating-ips/%s", fipID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FloatingIPNotFoundError{ID: fipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/floating-ips/%s", fipID), nil, connection.NotFoundResponseHandler(&FloatingIPNotFoundError{ID: fipID}))
+	return body.Data.TaskID, err
 }
 
 // AssignFloatingIP assigns a floating IP to a resource
 func (s *Service) AssignFloatingIP(fipID string, req AssignFloatingIPRequest) (string, error) {
-	body, err := s.assignFloatingIPResponseBody(fipID, req)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) assignFloatingIPResponseBody(fipID string, req AssignFloatingIPRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if fipID == "" {
-		return body, fmt.Errorf("invalid floating IP id")
+		return "", fmt.Errorf("invalid floating IP id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/floating-ips/%s/assign", fipID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FloatingIPNotFoundError{ID: fipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/floating-ips/%s/assign", fipID), &req, connection.NotFoundResponseHandler(&FloatingIPNotFoundError{ID: fipID}))
+	return body.Data.TaskID, err
 }
 
 // UnassignFloatingIP unassigns a floating IP from a resource
 func (s *Service) UnassignFloatingIP(fipID string) (string, error) {
-	body, err := s.unassignFloatingIPResponseBody(fipID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) unassignFloatingIPResponseBody(fipID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if fipID == "" {
-		return body, fmt.Errorf("invalid floating IP id")
+		return "", fmt.Errorf("invalid floating IP id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/floating-ips/%s/unassign", fipID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FloatingIPNotFoundError{ID: fipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/floating-ips/%s/unassign", fipID), nil, connection.NotFoundResponseHandler(&FloatingIPNotFoundError{ID: fipID}))
+	return body.Data.TaskID, err
 }
 
 // GetFloatingIPTasks retrieves a list of FloatingIP tasks
@@ -195,30 +77,11 @@ func (s *Service) GetFloatingIPTasks(fipID string, parameters connection.APIRequ
 
 // GetFloatingIPTasksPaginated retrieves a paginated list of FloatingIP tasks
 func (s *Service) GetFloatingIPTasksPaginated(fipID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getFloatingIPTasksPaginatedResponseBody(fipID, parameters)
-
+	if fipID == "" {
+		return nil, fmt.Errorf("invalid floating ip id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/floating-ips/%s/tasks", fipID), parameters, connection.NotFoundResponseHandler(&FloatingIPNotFoundError{ID: fipID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetFloatingIPTasksPaginated(fipID, p)
 	}), err
-}
-
-func (s *Service) getFloatingIPTasksPaginatedResponseBody(fipID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if fipID == "" {
-		return body, fmt.Errorf("invalid floating ip id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/floating-ips/%s/tasks", fipID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &FloatingIPNotFoundError{ID: fipID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_host.go
+++ b/pkg/service/ecloud/service_host.go
@@ -13,121 +13,41 @@ func (s *Service) GetHosts(parameters connection.APIRequestParameters) ([]Host, 
 
 // GetHostsPaginated retrieves a paginated list of hosts
 func (s *Service) GetHostsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Host], error) {
-	body, err := s.getHostsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Host](s.connection, "/ecloud/v2/hosts", parameters)
 	return connection.NewPaginated(body, parameters, s.GetHostsPaginated), err
-}
-
-func (s *Service) getHostsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Host], error) {
-	body := &connection.APIResponseBodyData[[]Host]{}
-
-	response, err := s.connection.Get("/ecloud/v2/hosts", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetHost retrieves a single host by id
 func (s *Service) GetHost(hostID string) (Host, error) {
-	body, err := s.getHostResponseBody(hostID)
-
-	return body.Data, err
-}
-
-func (s *Service) getHostResponseBody(hostID string) (*connection.APIResponseBodyData[Host], error) {
-	body := &connection.APIResponseBodyData[Host]{}
-
 	if hostID == "" {
-		return body, fmt.Errorf("invalid host id")
+		return Host{}, fmt.Errorf("invalid host id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/hosts/%s", hostID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostNotFoundError{ID: hostID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Host](s.connection, fmt.Sprintf("/ecloud/v2/hosts/%s", hostID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&HostNotFoundError{ID: hostID}))
+	return body.Data, err
 }
 
 // CreateHost creates a host
 func (s *Service) CreateHost(req CreateHostRequest) (TaskReference, error) {
-	body, err := s.createHostResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/hosts", &req)
 	return body.Data, err
-}
-
-func (s *Service) createHostResponseBody(req CreateHostRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/hosts", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchHost patches a host
 func (s *Service) PatchHost(hostID string, req PatchHostRequest) (TaskReference, error) {
-	body, err := s.patchHostResponseBody(hostID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchHostResponseBody(hostID string, req PatchHostRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if hostID == "" {
-		return body, fmt.Errorf("invalid host id")
+		return TaskReference{}, fmt.Errorf("invalid host id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/hosts/%s", hostID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostNotFoundError{ID: hostID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/hosts/%s", hostID), &req, connection.NotFoundResponseHandler(&HostNotFoundError{ID: hostID}))
+	return body.Data, err
 }
 
 // DeleteHost deletes a host
 func (s *Service) DeleteHost(hostID string) (string, error) {
-	body, err := s.deleteHostResponseBody(hostID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteHostResponseBody(hostID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if hostID == "" {
-		return body, fmt.Errorf("invalid host id")
+		return "", fmt.Errorf("invalid host id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/hosts/%s", hostID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostNotFoundError{ID: hostID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/hosts/%s", hostID), nil, connection.NotFoundResponseHandler(&HostNotFoundError{ID: hostID}))
+	return body.Data.TaskID, err
 }
 
 // GetHostTasks retrieves a list of Host tasks
@@ -139,30 +59,11 @@ func (s *Service) GetHostTasks(hostID string, parameters connection.APIRequestPa
 
 // GetHostTasksPaginated retrieves a paginated list of Host tasks
 func (s *Service) GetHostTasksPaginated(hostID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getHostTasksPaginatedResponseBody(hostID, parameters)
-
+	if hostID == "" {
+		return nil, fmt.Errorf("invalid host id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/hosts/%s/tasks", hostID), parameters, connection.NotFoundResponseHandler(&HostNotFoundError{ID: hostID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetHostTasksPaginated(hostID, p)
 	}), err
-}
-
-func (s *Service) getHostTasksPaginatedResponseBody(hostID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if hostID == "" {
-		return body, fmt.Errorf("invalid host id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/hosts/%s/tasks", hostID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostNotFoundError{ID: hostID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_hostgroup.go
+++ b/pkg/service/ecloud/service_hostgroup.go
@@ -13,121 +13,41 @@ func (s *Service) GetHostGroups(parameters connection.APIRequestParameters) ([]H
 
 // GetHostGroupsPaginated retrieves a paginated list of host groups
 func (s *Service) GetHostGroupsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[HostGroup], error) {
-	body, err := s.getHostGroupsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]HostGroup](s.connection, "/ecloud/v2/host-groups", parameters)
 	return connection.NewPaginated(body, parameters, s.GetHostGroupsPaginated), err
-}
-
-func (s *Service) getHostGroupsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]HostGroup], error) {
-	body := &connection.APIResponseBodyData[[]HostGroup]{}
-
-	response, err := s.connection.Get("/ecloud/v2/host-groups", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetHostGroup retrieves a single host group by id
 func (s *Service) GetHostGroup(hostGroupID string) (HostGroup, error) {
-	body, err := s.getHostGroupResponseBody(hostGroupID)
-
-	return body.Data, err
-}
-
-func (s *Service) getHostGroupResponseBody(hostGroupID string) (*connection.APIResponseBodyData[HostGroup], error) {
-	body := &connection.APIResponseBodyData[HostGroup]{}
-
 	if hostGroupID == "" {
-		return body, fmt.Errorf("invalid host group id")
+		return HostGroup{}, fmt.Errorf("invalid host group id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/host-groups/%s", hostGroupID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostGroupNotFoundError{ID: hostGroupID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[HostGroup](s.connection, fmt.Sprintf("/ecloud/v2/host-groups/%s", hostGroupID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&HostGroupNotFoundError{ID: hostGroupID}))
+	return body.Data, err
 }
 
 // CreateHostGroup creates a host group
 func (s *Service) CreateHostGroup(req CreateHostGroupRequest) (TaskReference, error) {
-	body, err := s.createHostGroupResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/host-groups", &req)
 	return body.Data, err
-}
-
-func (s *Service) createHostGroupResponseBody(req CreateHostGroupRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/host-groups", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchHostGroup patches a host group
 func (s *Service) PatchHostGroup(hostGroupID string, req PatchHostGroupRequest) (TaskReference, error) {
-	body, err := s.patchHostGroupResponseBody(hostGroupID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchHostGroupResponseBody(hostGroupID string, req PatchHostGroupRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if hostGroupID == "" {
-		return body, fmt.Errorf("invalid host group id")
+		return TaskReference{}, fmt.Errorf("invalid host group id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/host-groups/%s", hostGroupID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostGroupNotFoundError{ID: hostGroupID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/host-groups/%s", hostGroupID), &req, connection.NotFoundResponseHandler(&HostGroupNotFoundError{ID: hostGroupID}))
+	return body.Data, err
 }
 
 // DeleteHostGroup deletes a host group
 func (s *Service) DeleteHostGroup(hostGroupID string) (string, error) {
-	body, err := s.deleteHostGroupResponseBody(hostGroupID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteHostGroupResponseBody(hostGroupID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if hostGroupID == "" {
-		return body, fmt.Errorf("invalid host group id")
+		return "", fmt.Errorf("invalid host group id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/host-groups/%s", hostGroupID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostGroupNotFoundError{ID: hostGroupID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/host-groups/%s", hostGroupID), nil, connection.NotFoundResponseHandler(&HostGroupNotFoundError{ID: hostGroupID}))
+	return body.Data.TaskID, err
 }
 
 // GetHostGroupTasks retrieves a list of HostGroup tasks
@@ -139,30 +59,11 @@ func (s *Service) GetHostGroupTasks(hostGroupID string, parameters connection.AP
 
 // GetHostGroupTasksPaginated retrieves a paginated list of HostGroup tasks
 func (s *Service) GetHostGroupTasksPaginated(hostGroupID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getHostGroupTasksPaginatedResponseBody(hostGroupID, parameters)
-
+	if hostGroupID == "" {
+		return nil, fmt.Errorf("invalid host group id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/host-groups/%s/tasks", hostGroupID), parameters, connection.NotFoundResponseHandler(&HostGroupNotFoundError{ID: hostGroupID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetHostGroupTasksPaginated(hostGroupID, p)
 	}), err
-}
-
-func (s *Service) getHostGroupTasksPaginatedResponseBody(hostGroupID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if hostGroupID == "" {
-		return body, fmt.Errorf("invalid host group id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/host-groups/%s/tasks", hostGroupID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostGroupNotFoundError{ID: hostGroupID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_hostspec.go
+++ b/pkg/service/ecloud/service_hostspec.go
@@ -13,45 +13,15 @@ func (s *Service) GetHostSpecs(parameters connection.APIRequestParameters) ([]Ho
 
 // GetHostSpecsPaginated retrieves a paginated list of host specs
 func (s *Service) GetHostSpecsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[HostSpec], error) {
-	body, err := s.getHostSpecsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]HostSpec](s.connection, "/ecloud/v2/host-specs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetHostSpecsPaginated), err
-}
-
-func (s *Service) getHostSpecsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]HostSpec], error) {
-	body := &connection.APIResponseBodyData[[]HostSpec]{}
-
-	response, err := s.connection.Get("/ecloud/v2/host-specs", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetHostSpec retrieves a single host spec by id
 func (s *Service) GetHostSpec(specID string) (HostSpec, error) {
-	body, err := s.getHostSpecResponseBody(specID)
-
-	return body.Data, err
-}
-
-func (s *Service) getHostSpecResponseBody(specID string) (*connection.APIResponseBodyData[HostSpec], error) {
-	body := &connection.APIResponseBodyData[HostSpec]{}
-
 	if specID == "" {
-		return body, fmt.Errorf("invalid spec id")
+		return HostSpec{}, fmt.Errorf("invalid spec id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/host-specs/%s", specID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostSpecNotFoundError{ID: specID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[HostSpec](s.connection, fmt.Sprintf("/ecloud/v2/host-specs/%s", specID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&HostSpecNotFoundError{ID: specID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_image.go
+++ b/pkg/service/ecloud/service_image.go
@@ -13,77 +13,35 @@ func (s *Service) GetImages(parameters connection.APIRequestParameters) ([]Image
 
 // GetImagesPaginated retrieves a paginated list of images
 func (s *Service) GetImagesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Image], error) {
-	body, err := s.getImagesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Image](s.connection, "/ecloud/v2/images", parameters)
 	return connection.NewPaginated(body, parameters, s.GetImagesPaginated), err
-}
-
-func (s *Service) getImagesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Image], error) {
-	body := &connection.APIResponseBodyData[[]Image]{}
-
-	response, err := s.connection.Get("/ecloud/v2/images", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetImage retrieves a single Image by ID
 func (s *Service) GetImage(imageID string) (Image, error) {
-	body, err := s.getImageResponseBody(imageID)
-
-	return body.Data, err
-}
-
-func (s *Service) getImageResponseBody(imageID string) (*connection.APIResponseBodyData[Image], error) {
-	body := &connection.APIResponseBodyData[Image]{}
-
 	if imageID == "" {
-		return body, fmt.Errorf("invalid image id")
+		return Image{}, fmt.Errorf("invalid image id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/images/%s", imageID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ImageNotFoundError{ID: imageID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Image](s.connection, fmt.Sprintf("/ecloud/v2/images/%s", imageID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ImageNotFoundError{ID: imageID}))
+	return body.Data, err
 }
 
 // UpdateImage removes a single Image by ID
 func (s *Service) UpdateImage(imageID string, req UpdateImageRequest) (TaskReference, error) {
-	body, err := s.updateImageResponseBody(imageID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) updateImageResponseBody(imageID string, req UpdateImageRequest) (*connection.APIResponseBodyData[TaskReference], error) {
 	if imageID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid image id")
+		return TaskReference{}, fmt.Errorf("invalid image id")
 	}
-
-	return connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/images/%s", imageID), &req, connection.NotFoundResponseHandler(&ImageNotFoundError{ID: imageID}))
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/images/%s", imageID), &req, connection.NotFoundResponseHandler(&ImageNotFoundError{ID: imageID}))
+	return body.Data, err
 }
 
 // DeleteImage removes a single Image by ID
 func (s *Service) DeleteImage(imageID string) (string, error) {
-	body, err := s.deleteImageResponseBody(imageID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteImageResponseBody(imageID string) (*connection.APIResponseBodyData[TaskReference], error) {
 	if imageID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid image id")
+		return "", fmt.Errorf("invalid image id")
 	}
-
-	return connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/images/%s", imageID), nil, connection.NotFoundResponseHandler(&ImageNotFoundError{ID: imageID}))
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/images/%s", imageID), nil, connection.NotFoundResponseHandler(&ImageNotFoundError{ID: imageID}))
+	return body.Data.TaskID, err
 }
 
 // GetImageParameters retrieves a list of parameters
@@ -95,32 +53,13 @@ func (s *Service) GetImageParameters(imageID string, parameters connection.APIRe
 
 // GetImageParametersPaginated retrieves a paginated list of domains
 func (s *Service) GetImageParametersPaginated(imageID string, parameters connection.APIRequestParameters) (*connection.Paginated[ImageParameter], error) {
-	body, err := s.getImageParametersPaginatedResponseBody(imageID, parameters)
-
+	if imageID == "" {
+		return nil, fmt.Errorf("invalid image id")
+	}
+	body, err := connection.Get[[]ImageParameter](s.connection, fmt.Sprintf("/ecloud/v2/images/%s/parameters", imageID), parameters, connection.NotFoundResponseHandler(&ImageNotFoundError{ID: imageID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ImageParameter], error) {
 		return s.GetImageParametersPaginated(imageID, p)
 	}), err
-}
-
-func (s *Service) getImageParametersPaginatedResponseBody(imageID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ImageParameter], error) {
-	body := &connection.APIResponseBodyData[[]ImageParameter]{}
-
-	if imageID == "" {
-		return body, fmt.Errorf("invalid image id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/images/%s/parameters", imageID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ImageNotFoundError{ID: imageID}
-		}
-
-		return nil
-	})
 }
 
 // GetImageMetadata retrieves a list of metadata
@@ -132,30 +71,11 @@ func (s *Service) GetImageMetadata(imageID string, parameters connection.APIRequ
 
 // GetImageMetadataPaginated retrieves a paginated list of domains
 func (s *Service) GetImageMetadataPaginated(imageID string, parameters connection.APIRequestParameters) (*connection.Paginated[ImageMetadata], error) {
-	body, err := s.getImageMetadataPaginatedResponseBody(imageID, parameters)
-
+	if imageID == "" {
+		return nil, fmt.Errorf("invalid image id")
+	}
+	body, err := connection.Get[[]ImageMetadata](s.connection, fmt.Sprintf("/ecloud/v2/images/%s/metadata", imageID), parameters, connection.NotFoundResponseHandler(&ImageNotFoundError{ID: imageID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ImageMetadata], error) {
 		return s.GetImageMetadataPaginated(imageID, p)
 	}), err
-}
-
-func (s *Service) getImageMetadataPaginatedResponseBody(imageID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ImageMetadata], error) {
-	body := &connection.APIResponseBodyData[[]ImageMetadata]{}
-
-	if imageID == "" {
-		return body, fmt.Errorf("invalid image id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/images/%s/metadata", imageID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ImageNotFoundError{ID: imageID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_instance.go
+++ b/pkg/service/ecloud/service_instance.go
@@ -13,345 +13,109 @@ func (s *Service) GetInstances(parameters connection.APIRequestParameters) ([]In
 
 // GetInstancesPaginated retrieves a paginated list of instances
 func (s *Service) GetInstancesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
-	body, err := s.getInstancesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Instance](s.connection, "/ecloud/v2/instances", parameters)
 	return connection.NewPaginated(body, parameters, s.GetInstancesPaginated), err
-}
-
-func (s *Service) getInstancesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Instance], error) {
-	body := &connection.APIResponseBodyData[[]Instance]{}
-
-	response, err := s.connection.Get("/ecloud/v2/instances", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetInstance retrieves a single instance by id
 func (s *Service) GetInstance(instanceID string) (Instance, error) {
-	body, err := s.getInstanceResponseBody(instanceID)
-
-	return body.Data, err
-}
-
-func (s *Service) getInstanceResponseBody(instanceID string) (*connection.APIResponseBodyData[Instance], error) {
-	body := &connection.APIResponseBodyData[Instance]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return Instance{}, fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/instances/%s", instanceID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Instance](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s", instanceID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data, err
 }
 
 // CreateInstance creates a new instance
 func (s *Service) CreateInstance(req CreateInstanceRequest) (string, error) {
-	body, err := s.createInstanceResponseBody(req)
-
+	body, err := connection.Post[Instance](s.connection, "/ecloud/v2/instances", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createInstanceResponseBody(req CreateInstanceRequest) (*connection.APIResponseBodyData[Instance], error) {
-	body := &connection.APIResponseBodyData[Instance]{}
-
-	response, err := s.connection.Post("/ecloud/v2/instances", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchInstance updates an instance
 func (s *Service) PatchInstance(instanceID string, req PatchInstanceRequest) error {
-	_, err := s.patchInstanceResponseBody(instanceID, req)
-
-	return err
-}
-
-func (s *Service) patchInstanceResponseBody(instanceID string, req PatchInstanceRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/instances/%s", instanceID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ecloud/v2/instances/%s", instanceID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
 }
 
 // DeleteInstance removes an instance
 func (s *Service) DeleteInstance(instanceID string) error {
-	_, err := s.deleteInstanceResponseBody(instanceID)
-
-	return err
-}
-
-func (s *Service) deleteInstanceResponseBody(instanceID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/instances/%s", instanceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v2/instances/%s", instanceID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
 }
 
 // LockInstance locks an instance from update/removal
 func (s *Service) LockInstance(instanceID string) error {
-	_, err := s.lockInstanceResponseBody(instanceID)
-
-	return err
-}
-
-func (s *Service) lockInstanceResponseBody(instanceID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v2/instances/%s/lock", instanceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	return connection.PutRaw(s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/lock", instanceID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
 }
 
 // UnlockInstance unlocks an instance
 func (s *Service) UnlockInstance(instanceID string) error {
-	_, err := s.unlockInstanceResponseBody(instanceID)
-
-	return err
-}
-
-func (s *Service) unlockInstanceResponseBody(instanceID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v2/instances/%s/unlock", instanceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	return connection.PutRaw(s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/unlock", instanceID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
 }
 
 // PowerOnInstance powers on an instance
 func (s *Service) PowerOnInstance(instanceID string) (string, error) {
-	body, err := s.powerOnInstanceResponseBody(instanceID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) powerOnInstanceResponseBody(instanceID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v2/instances/%s/power-on", instanceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/power-on", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 // PowerOffInstance powers off an instance
 func (s *Service) PowerOffInstance(instanceID string) (string, error) {
-	body, err := s.powerOffInstanceResponseBody(instanceID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) powerOffInstanceResponseBody(instanceID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v2/instances/%s/power-off", instanceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/power-off", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 // PowerResetInstance resets an instance
 func (s *Service) PowerResetInstance(instanceID string) (string, error) {
-	body, err := s.powerResetInstanceResponseBody(instanceID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) powerResetInstanceResponseBody(instanceID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v2/instances/%s/power-reset", instanceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/power-reset", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 // PowerShutdownInstance shuts down an instance
 func (s *Service) PowerShutdownInstance(instanceID string) (string, error) {
-	body, err := s.powerShutdownInstanceResponseBody(instanceID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) powerShutdownInstanceResponseBody(instanceID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v2/instances/%s/power-shutdown", instanceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/power-shutdown", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 // PowerRestartInstance restarts an instance
 func (s *Service) PowerRestartInstance(instanceID string) (string, error) {
-	body, err := s.powerRestartInstanceResponseBody(instanceID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) powerRestartInstanceResponseBody(instanceID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v2/instances/%s/power-restart", instanceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/power-restart", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 // MigrateInstance migrates an instance
 func (s *Service) MigrateInstance(instanceID string, req MigrateInstanceRequest) (string, error) {
-	body, err := s.migrateInstanceResponseBody(instanceID, req)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) migrateInstanceResponseBody(instanceID string, req MigrateInstanceRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/instances/%s/migrate", instanceID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/migrate", instanceID), &req, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 // GetInstanceVolumes retrieves a list of instance volumes
@@ -363,32 +127,13 @@ func (s *Service) GetInstanceVolumes(instanceID string, parameters connection.AP
 
 // GetInstanceVolumesPaginated retrieves a paginated list of instance volumes
 func (s *Service) GetInstanceVolumesPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-	body, err := s.getInstanceVolumesPaginatedResponseBody(instanceID, parameters)
-
+	if instanceID == "" {
+		return nil, fmt.Errorf("invalid instance id")
+	}
+	body, err := connection.Get[[]Volume](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/volumes", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
 		return s.GetInstanceVolumesPaginated(instanceID, p)
 	}), err
-}
-
-func (s *Service) getInstanceVolumesPaginatedResponseBody(instanceID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Volume], error) {
-	body := &connection.APIResponseBodyData[[]Volume]{}
-
-	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/instances/%s/volumes", instanceID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
 }
 
 // GetInstanceCredentials retrieves a list of instance credentials
@@ -400,32 +145,13 @@ func (s *Service) GetInstanceCredentials(instanceID string, parameters connectio
 
 // GetInstanceCredentialsPaginated retrieves a paginated list of instance credentials
 func (s *Service) GetInstanceCredentialsPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[Credential], error) {
-	body, err := s.getInstanceCredentialsPaginatedResponseBody(instanceID, parameters)
-
+	if instanceID == "" {
+		return nil, fmt.Errorf("invalid instance id")
+	}
+	body, err := connection.Get[[]Credential](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/credentials", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Credential], error) {
 		return s.GetInstanceCredentialsPaginated(instanceID, p)
 	}), err
-}
-
-func (s *Service) getInstanceCredentialsPaginatedResponseBody(instanceID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Credential], error) {
-	body := &connection.APIResponseBodyData[[]Credential]{}
-
-	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/instances/%s/credentials", instanceID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
 }
 
 // GetInstanceNICs retrieves a list of instance NICs
@@ -437,60 +163,22 @@ func (s *Service) GetInstanceNICs(instanceID string, parameters connection.APIRe
 
 // GetInstanceNICsPaginated retrieves a paginated list of instance NICs
 func (s *Service) GetInstanceNICsPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
-	body, err := s.getInstanceNICsPaginatedResponseBody(instanceID, parameters)
-
+	if instanceID == "" {
+		return nil, fmt.Errorf("invalid instance id")
+	}
+	body, err := connection.Get[[]NIC](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/nics", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
 		return s.GetInstanceNICsPaginated(instanceID, p)
 	}), err
 }
 
-func (s *Service) getInstanceNICsPaginatedResponseBody(instanceID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]NIC], error) {
-	body := &connection.APIResponseBodyData[[]NIC]{}
-
-	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/instances/%s/nics", instanceID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
-}
-
 // CreateInstanceConsoleSession creates an instance console session
 func (s *Service) CreateInstanceConsoleSession(instanceID string) (ConsoleSession, error) {
-	body, err := s.createInstanceConsoleSessionResponseBody(instanceID)
-
-	return body.Data, err
-}
-
-func (s *Service) createInstanceConsoleSessionResponseBody(instanceID string) (*connection.APIResponseBodyData[ConsoleSession], error) {
-	body := &connection.APIResponseBodyData[ConsoleSession]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return ConsoleSession{}, fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/instances/%s/console-session", instanceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[ConsoleSession](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/console-session", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data, err
 }
 
 // GetInstanceTasks retrieves a list of Instance tasks
@@ -502,88 +190,31 @@ func (s *Service) GetInstanceTasks(instanceID string, parameters connection.APIR
 
 // GetInstanceTasksPaginated retrieves a paginated list of Instance tasks
 func (s *Service) GetInstanceTasksPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getInstanceTasksPaginatedResponseBody(instanceID, parameters)
-
+	if instanceID == "" {
+		return nil, fmt.Errorf("invalid instance id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/tasks", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetInstanceTasksPaginated(instanceID, p)
 	}), err
 }
 
-func (s *Service) getInstanceTasksPaginatedResponseBody(instanceID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/instances/%s/tasks", instanceID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
-}
-
 // AttachInstanceVolume attaches a volume to an instance
 func (s *Service) AttachInstanceVolume(instanceID string, req AttachDetachInstanceVolumeRequest) (string, error) {
-	body, err := s.attachInstanceVolumeResponseBody(instanceID, req)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) attachInstanceVolumeResponseBody(instanceID string, req AttachDetachInstanceVolumeRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/instances/%s/volume-attach", instanceID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/volume-attach", instanceID), &req, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 // DetachInstanceVolume detaches a volume from an instance
 func (s *Service) DetachInstanceVolume(instanceID string, req AttachDetachInstanceVolumeRequest) (string, error) {
-	body, err := s.detachInstanceVolumeResponseBody(instanceID, req)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) detachInstanceVolumeResponseBody(instanceID string, req AttachDetachInstanceVolumeRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/instances/%s/volume-detach", instanceID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/volume-detach", instanceID), &req, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 // GetInstanceFloatingIPs retrieves a list of instance fips
@@ -595,89 +226,46 @@ func (s *Service) GetInstanceFloatingIPs(instanceID string, parameters connectio
 
 // GetInstanceFloatingIPsPaginated retrieves a paginated list of instance floating IPs
 func (s *Service) GetInstanceFloatingIPsPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[FloatingIP], error) {
-	body, err := s.getInstanceFloatingIPsPaginatedResponseBody(instanceID, parameters)
-
+	if instanceID == "" {
+		return nil, fmt.Errorf("invalid instance id")
+	}
+	body, err := connection.Get[[]FloatingIP](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/floating-ips", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FloatingIP], error) {
 		return s.GetInstanceFloatingIPsPaginated(instanceID, p)
 	}), err
 }
 
-func (s *Service) getInstanceFloatingIPsPaginatedResponseBody(instanceID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]FloatingIP], error) {
-	body := &connection.APIResponseBodyData[[]FloatingIP]{}
-
-	if instanceID == "" {
-		return body, fmt.Errorf("invalid instance id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/instances/%s/floating-ips", instanceID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &InstanceNotFoundError{ID: instanceID}
-		}
-
-		return nil
-	})
-}
-
 // CreateInstanceImage attaches a volume to an instance
 func (s *Service) CreateInstanceImage(instanceID string, req CreateInstanceImageRequest) (TaskReference, error) {
-	body, err := s.createInstanceImageResponseBody(instanceID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) createInstanceImageResponseBody(instanceID string, req CreateInstanceImageRequest) (*connection.APIResponseBodyData[TaskReference], error) {
 	if instanceID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid instance id")
+		return TaskReference{}, fmt.Errorf("invalid instance id")
 	}
-
-	return connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/create-image", instanceID), &req, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	body, err := connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/create-image", instanceID), &req, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data, err
 }
 
 // EncryptInstance encrypts an instance
 func (s *Service) EncryptInstance(instanceID string) (string, error) {
-	body, err := s.encryptInstanceResponseBody(instanceID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) encryptInstanceResponseBody(instanceID string) (*connection.APIResponseBodyData[TaskReference], error) {
 	if instanceID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	return connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/encrypt", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	body, err := connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/encrypt", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 // DecryptInstance decrypts an instance
 func (s *Service) DecryptInstance(instanceID string) (string, error) {
-	body, err := s.decryptInstanceResponseBody(instanceID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) decryptInstanceResponseBody(instanceID string) (*connection.APIResponseBodyData[TaskReference], error) {
 	if instanceID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	return connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/decrypt", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	body, err := connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/decrypt", instanceID), nil, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }
 
 func (s *Service) ExecuteInstanceScript(instanceID string, req ExecuteInstanceScriptRequest) (string, error) {
-	body, err := s.executeInstanceScriptResponseBody(instanceID, req)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) executeInstanceScriptResponseBody(instanceID string, req ExecuteInstanceScriptRequest) (*connection.APIResponseBodyData[TaskReference], error) {
 	if instanceID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid instance id")
+		return "", fmt.Errorf("invalid instance id")
 	}
-
-	return connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/user-script", instanceID), &req, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	body, err := connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/user-script", instanceID), &req, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_iops.go
+++ b/pkg/service/ecloud/service_iops.go
@@ -13,45 +13,15 @@ func (s *Service) GetIOPSTiers(parameters connection.APIRequestParameters) ([]IO
 
 // GetIOPSsPaginated retrieves a paginated list of iops
 func (s *Service) GetIOPSTiersPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[IOPSTier], error) {
-	body, err := s.getIOPSsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]IOPSTier](s.connection, "/ecloud/v2/iops", parameters)
 	return connection.NewPaginated(body, parameters, s.GetIOPSTiersPaginated), err
-}
-
-func (s *Service) getIOPSsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]IOPSTier], error) {
-	body := &connection.APIResponseBodyData[[]IOPSTier]{}
-
-	response, err := s.connection.Get("/ecloud/v2/iops", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetIOPS retrieves a single IOPS by ID
 func (s *Service) GetIOPSTier(iopsID string) (IOPSTier, error) {
-	body, err := s.getIOPSTierResponseBody(iopsID)
-
-	return body.Data, err
-}
-
-func (s *Service) getIOPSTierResponseBody(iopsID string) (*connection.APIResponseBodyData[IOPSTier], error) {
-	body := &connection.APIResponseBodyData[IOPSTier]{}
-
 	if iopsID == "" {
-		return body, fmt.Errorf("invalid IOPS id")
+		return IOPSTier{}, fmt.Errorf("invalid IOPS id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/iops/%s", iopsID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &IOPSNotFoundError{ID: iopsID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[IOPSTier](s.connection, fmt.Sprintf("/ecloud/v2/iops/%s", iopsID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&IOPSNotFoundError{ID: iopsID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_ipaddress.go
+++ b/pkg/service/ecloud/service_ipaddress.go
@@ -13,119 +13,39 @@ func (s *Service) GetIPAddresses(parameters connection.APIRequestParameters) ([]
 
 // GetIPAddressesPaginated retrieves a paginated list of ips
 func (s *Service) GetIPAddressesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[IPAddress], error) {
-	body, err := s.getIPAddressesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]IPAddress](s.connection, "/ecloud/v2/ip-addresses", parameters)
 	return connection.NewPaginated(body, parameters, s.GetIPAddressesPaginated), err
-}
-
-func (s *Service) getIPAddressesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]IPAddress], error) {
-	body := &connection.APIResponseBodyData[[]IPAddress]{}
-
-	response, err := s.connection.Get("/ecloud/v2/ip-addresses", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetIPAddress retrieves a single ip by id
 func (s *Service) GetIPAddress(ipID string) (IPAddress, error) {
-	body, err := s.getIPAddressResponseBody(ipID)
-
-	return body.Data, err
-}
-
-func (s *Service) getIPAddressResponseBody(ipID string) (*connection.APIResponseBodyData[IPAddress], error) {
-	body := &connection.APIResponseBodyData[IPAddress]{}
-
 	if ipID == "" {
-		return body, fmt.Errorf("invalid ip address id")
+		return IPAddress{}, fmt.Errorf("invalid ip address id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/ip-addresses/%s", ipID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &IPAddressNotFoundError{ID: ipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[IPAddress](s.connection, fmt.Sprintf("/ecloud/v2/ip-addresses/%s", ipID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&IPAddressNotFoundError{ID: ipID}))
+	return body.Data, err
 }
 
 // CreateIPAddress creates a new IPAddress
 func (s *Service) CreateIPAddress(req CreateIPAddressRequest) (TaskReference, error) {
-	body, err := s.createIPAddressResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/ip-addresses", &req)
 	return body.Data, err
-}
-
-func (s *Service) createIPAddressResponseBody(req CreateIPAddressRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/ip-addresses", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchIPAddress patches a IPAddress
 func (s *Service) PatchIPAddress(ipID string, req PatchIPAddressRequest) (TaskReference, error) {
-	body, err := s.patchIPAddressResponseBody(ipID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchIPAddressResponseBody(ipID string, req PatchIPAddressRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ipID == "" {
-		return body, fmt.Errorf("invalid ip address id")
+		return TaskReference{}, fmt.Errorf("invalid ip address id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/ip-addresses/%s", ipID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &IPAddressNotFoundError{ID: ipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/ip-addresses/%s", ipID), &req, connection.NotFoundResponseHandler(&IPAddressNotFoundError{ID: ipID}))
+	return body.Data, err
 }
 
 // DeleteIPAddress deletes a IPAddress
 func (s *Service) DeleteIPAddress(ipID string) (string, error) {
-	body, err := s.deleteIPAddressResponseBody(ipID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteIPAddressResponseBody(ipID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ipID == "" {
-		return body, fmt.Errorf("invalid ip address id")
+		return "", fmt.Errorf("invalid ip address id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/ip-addresses/%s", ipID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &IPAddressNotFoundError{ID: ipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/ip-addresses/%s", ipID), nil, connection.NotFoundResponseHandler(&IPAddressNotFoundError{ID: ipID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_loadbalancer.go
+++ b/pkg/service/ecloud/service_loadbalancer.go
@@ -13,119 +13,39 @@ func (s *Service) GetLoadBalancers(parameters connection.APIRequestParameters) (
 
 // GetLoadBalancersPaginated retrieves a paginated list of lbs
 func (s *Service) GetLoadBalancersPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[LoadBalancer], error) {
-	body, err := s.getLoadBalancersPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]LoadBalancer](s.connection, "/ecloud/v2/load-balancers", parameters)
 	return connection.NewPaginated(body, parameters, s.GetLoadBalancersPaginated), err
-}
-
-func (s *Service) getLoadBalancersPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]LoadBalancer], error) {
-	body := &connection.APIResponseBodyData[[]LoadBalancer]{}
-
-	response, err := s.connection.Get("/ecloud/v2/load-balancers", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetLoadBalancer retrieves a single lb by id
 func (s *Service) GetLoadBalancer(loadbalancerID string) (LoadBalancer, error) {
-	body, err := s.getLoadBalancerResponseBody(loadbalancerID)
-
-	return body.Data, err
-}
-
-func (s *Service) getLoadBalancerResponseBody(loadbalancerID string) (*connection.APIResponseBodyData[LoadBalancer], error) {
-	body := &connection.APIResponseBodyData[LoadBalancer]{}
-
 	if loadbalancerID == "" {
-		return body, fmt.Errorf("invalid load balancer id")
+		return LoadBalancer{}, fmt.Errorf("invalid load balancer id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/load-balancers/%s", loadbalancerID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &LoadBalancerNotFoundError{ID: loadbalancerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[LoadBalancer](s.connection, fmt.Sprintf("/ecloud/v2/load-balancers/%s", loadbalancerID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&LoadBalancerNotFoundError{ID: loadbalancerID}))
+	return body.Data, err
 }
 
 // CreateLoadBalancer creates a new LoadBalancer
 func (s *Service) CreateLoadBalancer(req CreateLoadBalancerRequest) (TaskReference, error) {
-	body, err := s.createLoadBalancerResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/load-balancers", &req)
 	return body.Data, err
-}
-
-func (s *Service) createLoadBalancerResponseBody(req CreateLoadBalancerRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/load-balancers", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchLoadBalancer patches a LoadBalancer
 func (s *Service) PatchLoadBalancer(loadbalancerID string, req PatchLoadBalancerRequest) (TaskReference, error) {
-	body, err := s.patchLoadBalancerResponseBody(loadbalancerID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchLoadBalancerResponseBody(loadbalancerID string, req PatchLoadBalancerRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if loadbalancerID == "" {
-		return body, fmt.Errorf("invalid load balancer id")
+		return TaskReference{}, fmt.Errorf("invalid load balancer id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/load-balancers/%s", loadbalancerID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &LoadBalancerNotFoundError{ID: loadbalancerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/load-balancers/%s", loadbalancerID), &req, connection.NotFoundResponseHandler(&LoadBalancerNotFoundError{ID: loadbalancerID}))
+	return body.Data, err
 }
 
 // DeleteLoadBalancer deletes a LoadBalancer
 func (s *Service) DeleteLoadBalancer(loadbalancerID string) (string, error) {
-	body, err := s.deleteLoadBalancerResponseBody(loadbalancerID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteLoadBalancerResponseBody(loadbalancerID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if loadbalancerID == "" {
-		return body, fmt.Errorf("invalid load balancer id")
+		return "", fmt.Errorf("invalid load balancer id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/load-balancers/%s", loadbalancerID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &LoadBalancerNotFoundError{ID: loadbalancerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/load-balancers/%s", loadbalancerID), nil, connection.NotFoundResponseHandler(&LoadBalancerNotFoundError{ID: loadbalancerID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_loadbalancerspec.go
+++ b/pkg/service/ecloud/service_loadbalancerspec.go
@@ -13,45 +13,15 @@ func (s *Service) GetLoadBalancerSpecs(parameters connection.APIRequestParameter
 
 // GetLoadBalancerSpecsPaginated retrieves a paginated list of load balancer specs
 func (s *Service) GetLoadBalancerSpecsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[LoadBalancerSpec], error) {
-	body, err := s.getLoadBalancerSpecsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]LoadBalancerSpec](s.connection, "/ecloud/v2/load-balancer-specs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetLoadBalancerSpecsPaginated), err
-}
-
-func (s *Service) getLoadBalancerSpecsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]LoadBalancerSpec], error) {
-	body := &connection.APIResponseBodyData[[]LoadBalancerSpec]{}
-
-	response, err := s.connection.Get("/ecloud/v2/load-balancer-specs", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetLoadBalancerSpec retrieves a single spec by id
 func (s *Service) GetLoadBalancerSpec(lbSpecID string) (LoadBalancerSpec, error) {
-	body, err := s.getLoadBalancerSpecResponseBody(lbSpecID)
-
-	return body.Data, err
-}
-
-func (s *Service) getLoadBalancerSpecResponseBody(lbSpecID string) (*connection.APIResponseBodyData[LoadBalancerSpec], error) {
-	body := &connection.APIResponseBodyData[LoadBalancerSpec]{}
-
 	if lbSpecID == "" {
-		return body, fmt.Errorf("invalid load balancer spec id")
+		return LoadBalancerSpec{}, fmt.Errorf("invalid load balancer spec id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/load-balancer-specs/%s", lbSpecID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &LoadBalancerSpecNotFoundError{ID: lbSpecID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[LoadBalancerSpec](s.connection, fmt.Sprintf("/ecloud/v2/load-balancer-specs/%s", lbSpecID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&LoadBalancerSpecNotFoundError{ID: lbSpecID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_monitoringgateway.go
+++ b/pkg/service/ecloud/service_monitoringgateway.go
@@ -13,83 +13,39 @@ func (s *Service) GetMonitoringGateways(parameters connection.APIRequestParamete
 
 // GetMonitoringGatewaysPaginated retrieves a paginated list of monitoring gateways
 func (s *Service) GetMonitoringGatewaysPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[MonitoringGateway], error) {
-	body, err := s.GetMonitoringGatewaysPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]MonitoringGateway](s.connection, "/ecloud/v2/monitoring-gateways", parameters)
 	return connection.NewPaginated(body, parameters, s.GetMonitoringGatewaysPaginated), err
-}
-
-func (s *Service) GetMonitoringGatewaysPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]MonitoringGateway], error) {
-	body := &connection.APIResponseBodyData[[]MonitoringGateway]{}
-
-	response, err := s.connection.Get("/ecloud/v2/monitoring-gateways", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetMonitoringGateway retrieves a single monitoring gateway by ID
 func (s *Service) GetMonitoringGateway(gatewayID string) (MonitoringGateway, error) {
-	body, err := s.getMonitoringGatewayResponseBody(gatewayID)
-
-	return body.Data, err
-}
-
-func (s *Service) getMonitoringGatewayResponseBody(gatewayID string) (*connection.APIResponseBodyData[MonitoringGateway], error) {
 	if gatewayID == "" {
-		return &connection.APIResponseBodyData[MonitoringGateway]{}, fmt.Errorf("invalid monitoring gateway id")
+		return MonitoringGateway{}, fmt.Errorf("invalid monitoring gateway id")
 	}
-
-	return connection.Get[MonitoringGateway](s.connection, fmt.Sprintf("/ecloud/v2/monitoring-gateways/%s", gatewayID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&MonitoringGatewayNotFoundError{ID: gatewayID}))
+	body, err := connection.Get[MonitoringGateway](s.connection, fmt.Sprintf("/ecloud/v2/monitoring-gateways/%s", gatewayID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&MonitoringGatewayNotFoundError{ID: gatewayID}))
+	return body.Data, err
 }
 
 // CreateMonitoringGateway creates a new monitoring gateway
 func (s *Service) CreateMonitoringGateway(req CreateMonitoringGatewayRequest) (TaskReference, error) {
-	body, err := s.createMonitoringGatewayResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/monitoring-gateways", &req)
 	return body.Data, err
-}
-
-func (s *Service) createMonitoringGatewayResponseBody(req CreateMonitoringGatewayRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	return connection.Post[TaskReference](s.connection, "/ecloud/v2/monitoring-gateways", &req)
 }
 
 // PatchMonitoringGateway patches a monitoring gateway
 func (s *Service) PatchMonitoringGateway(gatewayID string, req PatchMonitoringGatewayRequest) (TaskReference, error) {
-	body, err := s.patchMonitoringGatewayResponseBody(gatewayID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchMonitoringGatewayResponseBody(gatewayID string, req PatchMonitoringGatewayRequest) (*connection.APIResponseBodyData[TaskReference], error) {
 	if gatewayID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid gateway id")
+		return TaskReference{}, fmt.Errorf("invalid gateway id")
 	}
-
-	return connection.Patch[TaskReference](
-		s.connection,
-		fmt.Sprintf("/ecloud/v2/monitoring-gateways/%s", gatewayID),
-		&req,
-		connection.NotFoundResponseHandler(&MonitoringGatewayNotFoundError{ID: gatewayID}),
-	)
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/monitoring-gateways/%s", gatewayID), &req, connection.NotFoundResponseHandler(&MonitoringGatewayNotFoundError{ID: gatewayID}))
+	return body.Data, err
 }
 
 // DeleteMonitoringGateway deletes a monitoring gateway
 func (s *Service) DeleteMonitoringGateway(gatewayID string) (string, error) {
-	body, err := s.deleteMonitoringGatewayResponseBody(gatewayID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteMonitoringGatewayResponseBody(gatewayID string) (*connection.APIResponseBodyData[TaskReference], error) {
 	if gatewayID == "" {
-		return &connection.APIResponseBodyData[TaskReference]{}, fmt.Errorf("invalid gateway id")
+		return "", fmt.Errorf("invalid gateway id")
 	}
-
-	return connection.Delete[TaskReference](
-		s.connection,
-		fmt.Sprintf("/ecloud/v2/monitoring-gateways/%s", gatewayID),
-		nil,
-		connection.NotFoundResponseHandler(&MonitoringGatewayNotFoundError{ID: gatewayID}),
-	)
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/monitoring-gateways/%s", gatewayID), nil, connection.NotFoundResponseHandler(&MonitoringGatewayNotFoundError{ID: gatewayID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_natoverloadrule.go
+++ b/pkg/service/ecloud/service_natoverloadrule.go
@@ -13,39 +13,22 @@ func (s *Service) GetNATOverloadRules(parameters connection.APIRequestParameters
 
 // GetNATOverloadRulesPaginated retrieves a paginated list of NAT overload rules
 func (s *Service) GetNATOverloadRulesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[NATOverloadRule], error) {
-	body, err := s.getNATOverloadRulesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]NATOverloadRule](s.connection, "/ecloud/v2/nat-overload-rules", parameters)
 	return connection.NewPaginated(body, parameters, s.GetNATOverloadRulesPaginated), err
-}
-
-func (s *Service) getNATOverloadRulesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]NATOverloadRule], error) {
-	return connection.Get[[]NATOverloadRule](s.connection, "/ecloud/v2/nat-overload-rules", parameters)
 }
 
 // GetNATOverloadRule retrieves a single NAT overload rule by id
 func (s *Service) GetNATOverloadRule(ruleID string) (NATOverloadRule, error) {
-	body, err := s.getNATOverloadRuleResponseBody(ruleID)
-	if err != nil {
-		return NATOverloadRule{}, err
-	}
-
-	return body.Data, err
-}
-
-func (s *Service) getNATOverloadRuleResponseBody(ruleID string) (*connection.APIResponseBodyData[NATOverloadRule], error) {
 	if ruleID == "" {
-		return nil, fmt.Errorf("invalid nat overload rule id")
+		return NATOverloadRule{}, fmt.Errorf("invalid nat overload rule id")
 	}
-
-	return connection.Get[NATOverloadRule](s.connection, fmt.Sprintf("/ecloud/v2/nat-overload-rules/%s", ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&NATOverloadRuleNotFoundError{ID: ruleID}))
+	body, err := connection.Get[NATOverloadRule](s.connection, fmt.Sprintf("/ecloud/v2/nat-overload-rules/%s", ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&NATOverloadRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // CreateNATOverloadRule creates a new NAT overload
 func (s *Service) CreateNATOverloadRule(req CreateNATOverloadRuleRequest) (TaskReference, error) {
 	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/nat-overload-rules", &req)
-	if err != nil {
-		return TaskReference{}, err
-	}
-
 	return body.Data, err
 }
 
@@ -54,12 +37,7 @@ func (s *Service) PatchNATOverloadRule(ruleID string, req PatchNATOverloadRuleRe
 	if ruleID == "" {
 		return TaskReference{}, fmt.Errorf("invalid nat overload rule id")
 	}
-
 	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/nat-overload-rules/%s", ruleID), &req, connection.NotFoundResponseHandler(&NATOverloadRuleNotFoundError{ID: ruleID}))
-	if err != nil {
-		return TaskReference{}, err
-	}
-
 	return body.Data, err
 }
 
@@ -68,11 +46,6 @@ func (s *Service) DeleteNATOverloadRule(ruleID string) (string, error) {
 	if ruleID == "" {
 		return "", fmt.Errorf("invalid nat overload rule id")
 	}
-
 	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/nat-overload-rules/%s", ruleID), nil, connection.NotFoundResponseHandler(&NATOverloadRuleNotFoundError{ID: ruleID}))
-	if err != nil {
-		return "", err
-	}
-
 	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_network.go
+++ b/pkg/service/ecloud/service_network.go
@@ -13,121 +13,39 @@ func (s *Service) GetNetworks(parameters connection.APIRequestParameters) ([]Net
 
 // GetNetworksPaginated retrieves a paginated list of networks
 func (s *Service) GetNetworksPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Network], error) {
-	body, err := s.getNetworksPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Network](s.connection, "/ecloud/v2/networks", parameters)
 	return connection.NewPaginated(body, parameters, s.GetNetworksPaginated), err
-}
-
-func (s *Service) getNetworksPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Network], error) {
-	body := &connection.APIResponseBodyData[[]Network]{}
-
-	response, err := s.connection.Get("/ecloud/v2/networks", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetNetwork retrieves a single network by id
 func (s *Service) GetNetwork(networkID string) (Network, error) {
-	body, err := s.getNetworkResponseBody(networkID)
-
-	return body.Data, err
-}
-
-func (s *Service) getNetworkResponseBody(networkID string) (*connection.APIResponseBodyData[Network], error) {
-	body := &connection.APIResponseBodyData[Network]{}
-
 	if networkID == "" {
-		return body, fmt.Errorf("invalid network id")
+		return Network{}, fmt.Errorf("invalid network id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/networks/%s", networkID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkNotFoundError{ID: networkID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Network](s.connection, fmt.Sprintf("/ecloud/v2/networks/%s", networkID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&NetworkNotFoundError{ID: networkID}))
+	return body.Data, err
 }
 
 // CreateNetwork creates a new Network
 func (s *Service) CreateNetwork(req CreateNetworkRequest) (string, error) {
-	body, err := s.createNetworkResponseBody(req)
-
+	body, err := connection.Post[Network](s.connection, "/ecloud/v2/networks", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createNetworkResponseBody(req CreateNetworkRequest) (*connection.APIResponseBodyData[Network], error) {
-	body := &connection.APIResponseBodyData[Network]{}
-
-	response, err := s.connection.Post("/ecloud/v2/networks", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchNetwork patches a Network
 func (s *Service) PatchNetwork(networkID string, req PatchNetworkRequest) error {
-	_, err := s.patchNetworkResponseBody(networkID, req)
-
-	return err
-}
-
-func (s *Service) patchNetworkResponseBody(networkID string, req PatchNetworkRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if networkID == "" {
-		return body, fmt.Errorf("invalid network id")
+		return fmt.Errorf("invalid network id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/networks/%s", networkID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkNotFoundError{ID: networkID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ecloud/v2/networks/%s", networkID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&NetworkNotFoundError{ID: networkID}))
 }
 
 // DeleteNetwork deletes a Network
 func (s *Service) DeleteNetwork(networkID string) error {
-	_, err := s.deleteNetworkResponseBody(networkID)
-
-	return err
-}
-
-func (s *Service) deleteNetworkResponseBody(networkID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if networkID == "" {
-		return body, fmt.Errorf("invalid network id")
+		return fmt.Errorf("invalid network id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/networks/%s", networkID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkNotFoundError{ID: networkID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v2/networks/%s", networkID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&NetworkNotFoundError{ID: networkID}))
 }
 
 // GetNetworkNICs retrieves a list of firewall rule nics
@@ -139,22 +57,10 @@ func (s *Service) GetNetworkNICs(networkID string, parameters connection.APIRequ
 
 // GetNetworkNICsPaginated retrieves a paginated list of firewall rule nics
 func (s *Service) GetNetworkNICsPaginated(networkID string, parameters connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
-	body, err := s.getNetworkNICsPaginatedResponseBody(networkID, parameters)
-
+	body, err := connection.Get[[]NIC](s.connection, fmt.Sprintf("/ecloud/v2/networks/%s/nics", networkID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
 		return s.GetNetworkNICsPaginated(networkID, p)
 	}), err
-}
-
-func (s *Service) getNetworkNICsPaginatedResponseBody(networkID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]NIC], error) {
-	body := &connection.APIResponseBodyData[[]NIC]{}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/networks/%s/nics", networkID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetNetworkTasks retrieves a list of Network tasks
@@ -166,30 +72,11 @@ func (s *Service) GetNetworkTasks(networkID string, parameters connection.APIReq
 
 // GetNetworkTasksPaginated retrieves a paginated list of Network tasks
 func (s *Service) GetNetworkTasksPaginated(networkID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getNetworkTasksPaginatedResponseBody(networkID, parameters)
-
+	if networkID == "" {
+		return nil, fmt.Errorf("invalid network id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/networks/%s/tasks", networkID), parameters, connection.NotFoundResponseHandler(&NetworkNotFoundError{ID: networkID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetNetworkTasksPaginated(networkID, p)
 	}), err
-}
-
-func (s *Service) getNetworkTasksPaginatedResponseBody(networkID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if networkID == "" {
-		return body, fmt.Errorf("invalid network id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/networks/%s/tasks", networkID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkNotFoundError{ID: networkID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_networkpolicy.go
+++ b/pkg/service/ecloud/service_networkpolicy.go
@@ -13,121 +13,41 @@ func (s *Service) GetNetworkPolicies(parameters connection.APIRequestParameters)
 
 // GetNetworkPoliciesPaginated retrieves a paginated list of network policies
 func (s *Service) GetNetworkPoliciesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[NetworkPolicy], error) {
-	body, err := s.getNetworkPoliciesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]NetworkPolicy](s.connection, "/ecloud/v2/network-policies", parameters)
 	return connection.NewPaginated(body, parameters, s.GetNetworkPoliciesPaginated), err
-}
-
-func (s *Service) getNetworkPoliciesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]NetworkPolicy], error) {
-	body := &connection.APIResponseBodyData[[]NetworkPolicy]{}
-
-	response, err := s.connection.Get("/ecloud/v2/network-policies", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetNetworkPolicy retrieves a single network policy by id
 func (s *Service) GetNetworkPolicy(policyID string) (NetworkPolicy, error) {
-	body, err := s.getNetworkPolicyResponseBody(policyID)
-
-	return body.Data, err
-}
-
-func (s *Service) getNetworkPolicyResponseBody(policyID string) (*connection.APIResponseBodyData[NetworkPolicy], error) {
-	body := &connection.APIResponseBodyData[NetworkPolicy]{}
-
 	if policyID == "" {
-		return body, fmt.Errorf("invalid network policy id")
+		return NetworkPolicy{}, fmt.Errorf("invalid network policy id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/network-policies/%s", policyID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[NetworkPolicy](s.connection, fmt.Sprintf("/ecloud/v2/network-policies/%s", policyID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&NetworkPolicyNotFoundError{ID: policyID}))
+	return body.Data, err
 }
 
 // CreateNetworkPolicy creates a new NetworkPolicy
 func (s *Service) CreateNetworkPolicy(req CreateNetworkPolicyRequest) (TaskReference, error) {
-	body, err := s.createNetworkPolicyResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/network-policies", &req)
 	return body.Data, err
-}
-
-func (s *Service) createNetworkPolicyResponseBody(req CreateNetworkPolicyRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/network-policies", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchNetworkPolicy patches a NetworkPolicy
 func (s *Service) PatchNetworkPolicy(policyID string, req PatchNetworkPolicyRequest) (TaskReference, error) {
-	body, err := s.patchNetworkPolicyResponseBody(policyID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchNetworkPolicyResponseBody(policyID string, req PatchNetworkPolicyRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if policyID == "" {
-		return body, fmt.Errorf("invalid policy id")
+		return TaskReference{}, fmt.Errorf("invalid policy id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/network-policies/%s", policyID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/network-policies/%s", policyID), &req, connection.NotFoundResponseHandler(&NetworkPolicyNotFoundError{ID: policyID}))
+	return body.Data, err
 }
 
 // DeleteNetworkPolicy deletes a NetworkPolicy
 func (s *Service) DeleteNetworkPolicy(policyID string) (string, error) {
-	body, err := s.deleteNetworkPolicyResponseBody(policyID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteNetworkPolicyResponseBody(policyID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if policyID == "" {
-		return body, fmt.Errorf("invalid policy id")
+		return "", fmt.Errorf("invalid policy id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/network-policies/%s", policyID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/network-policies/%s", policyID), nil, connection.NotFoundResponseHandler(&NetworkPolicyNotFoundError{ID: policyID}))
+	return body.Data.TaskID, err
 }
 
 // GetNetworkPolicyNetworkRules retrieves a list of network policy rules
@@ -139,32 +59,13 @@ func (s *Service) GetNetworkPolicyNetworkRules(policyID string, parameters conne
 
 // GetNetworkPolicyNetworkRulesPaginated retrieves a paginated list of network policy NetworkRules
 func (s *Service) GetNetworkPolicyNetworkRulesPaginated(policyID string, parameters connection.APIRequestParameters) (*connection.Paginated[NetworkRule], error) {
-	body, err := s.getNetworkPolicyNetworkRulesPaginatedResponseBody(policyID, parameters)
-
+	if policyID == "" {
+		return nil, fmt.Errorf("invalid network policy id")
+	}
+	body, err := connection.Get[[]NetworkRule](s.connection, fmt.Sprintf("/ecloud/v2/network-policies/%s/network-rules", policyID), parameters, connection.NotFoundResponseHandler(&NetworkPolicyNotFoundError{ID: policyID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[NetworkRule], error) {
 		return s.GetNetworkPolicyNetworkRulesPaginated(policyID, p)
 	}), err
-}
-
-func (s *Service) getNetworkPolicyNetworkRulesPaginatedResponseBody(policyID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]NetworkRule], error) {
-	body := &connection.APIResponseBodyData[[]NetworkRule]{}
-
-	if policyID == "" {
-		return body, fmt.Errorf("invalid network policy id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/network-policies/%s/network-rules", policyID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
 }
 
 // GetNetworkPolicyTasks retrieves a list of NetworkPolicy tasks
@@ -176,30 +77,11 @@ func (s *Service) GetNetworkPolicyTasks(policyID string, parameters connection.A
 
 // GetNetworkPolicyTasksPaginated retrieves a paginated list of NetworkPolicy tasks
 func (s *Service) GetNetworkPolicyTasksPaginated(policyID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getNetworkPolicyTasksPaginatedResponseBody(policyID, parameters)
-
+	if policyID == "" {
+		return nil, fmt.Errorf("invalid network policy id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/network-policies/%s/tasks", policyID), parameters, connection.NotFoundResponseHandler(&NetworkPolicyNotFoundError{ID: policyID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetNetworkPolicyTasksPaginated(policyID, p)
 	}), err
-}
-
-func (s *Service) getNetworkPolicyTasksPaginatedResponseBody(policyID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if policyID == "" {
-		return body, fmt.Errorf("invalid network policy id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/network-policies/%s/tasks", policyID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkPolicyNotFoundError{ID: policyID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_networkrule.go
+++ b/pkg/service/ecloud/service_networkrule.go
@@ -13,121 +13,41 @@ func (s *Service) GetNetworkRules(parameters connection.APIRequestParameters) ([
 
 // GetNetworkRulesPaginated retrieves a paginated list of network rules
 func (s *Service) GetNetworkRulesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[NetworkRule], error) {
-	body, err := s.getNetworkRulesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]NetworkRule](s.connection, "/ecloud/v2/network-rules", parameters)
 	return connection.NewPaginated(body, parameters, s.GetNetworkRulesPaginated), err
-}
-
-func (s *Service) getNetworkRulesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]NetworkRule], error) {
-	body := &connection.APIResponseBodyData[[]NetworkRule]{}
-
-	response, err := s.connection.Get("/ecloud/v2/network-rules", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetNetworkRule retrieves a single rule by id
 func (s *Service) GetNetworkRule(ruleID string) (NetworkRule, error) {
-	body, err := s.getNetworkRuleResponseBody(ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getNetworkRuleResponseBody(ruleID string) (*connection.APIResponseBodyData[NetworkRule], error) {
-	body := &connection.APIResponseBodyData[NetworkRule]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid network rule id")
+		return NetworkRule{}, fmt.Errorf("invalid network rule id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/network-rules/%s", ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[NetworkRule](s.connection, fmt.Sprintf("/ecloud/v2/network-rules/%s", ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&NetworkRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // CreateNetworkRule creates a new NetworkRule
 func (s *Service) CreateNetworkRule(req CreateNetworkRuleRequest) (TaskReference, error) {
-	body, err := s.createNetworkRuleResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/network-rules", &req)
 	return body.Data, err
-}
-
-func (s *Service) createNetworkRuleResponseBody(req CreateNetworkRuleRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/network-rules", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchNetworkRule patches a NetworkRule
 func (s *Service) PatchNetworkRule(ruleID string, req PatchNetworkRuleRequest) (TaskReference, error) {
-	body, err := s.patchNetworkRuleResponseBody(ruleID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchNetworkRuleResponseBody(ruleID string, req PatchNetworkRuleRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid network rule id")
+		return TaskReference{}, fmt.Errorf("invalid network rule id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/network-rules/%s", ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/network-rules/%s", ruleID), &req, connection.NotFoundResponseHandler(&NetworkRuleNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // DeleteNetworkRule deletes a NetworkRule
 func (s *Service) DeleteNetworkRule(ruleID string) (string, error) {
-	body, err := s.deleteNetworkRuleResponseBody(ruleID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteNetworkRuleResponseBody(ruleID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid network rule id")
+		return "", fmt.Errorf("invalid network rule id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/network-rules/%s", ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkRuleNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/network-rules/%s", ruleID), nil, connection.NotFoundResponseHandler(&NetworkRuleNotFoundError{ID: ruleID}))
+	return body.Data.TaskID, err
 }
 
 // GetNetworkRuleNetworkRulePorts retrieves a list of network rule ports
@@ -139,20 +59,8 @@ func (s *Service) GetNetworkRuleNetworkRulePorts(networkRuleID string, parameter
 
 // GetNetworkRuleNetworkRulePortsPaginated retrieves a paginated list of network rule ports
 func (s *Service) GetNetworkRuleNetworkRulePortsPaginated(networkRuleID string, parameters connection.APIRequestParameters) (*connection.Paginated[NetworkRulePort], error) {
-	body, err := s.getNetworkRuleNetworkRulePortsPaginatedResponseBody(networkRuleID, parameters)
-
+	body, err := connection.Get[[]NetworkRulePort](s.connection, fmt.Sprintf("/ecloud/v2/network-rules/%s/ports", networkRuleID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[NetworkRulePort], error) {
 		return s.GetNetworkRuleNetworkRulePortsPaginated(networkRuleID, p)
 	}), err
-}
-
-func (s *Service) getNetworkRuleNetworkRulePortsPaginatedResponseBody(networkRuleID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]NetworkRulePort], error) {
-	body := &connection.APIResponseBodyData[[]NetworkRulePort]{}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/network-rules/%s/ports", networkRuleID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/ecloud/service_networkruleport.go
+++ b/pkg/service/ecloud/service_networkruleport.go
@@ -13,119 +13,39 @@ func (s *Service) GetNetworkRulePorts(parameters connection.APIRequestParameters
 
 // GetNetworkRulePortsPaginated retrieves a paginated list of network rules
 func (s *Service) GetNetworkRulePortsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[NetworkRulePort], error) {
-	body, err := s.getNetworkRulePortsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]NetworkRulePort](s.connection, "/ecloud/v2/network-rule-ports", parameters)
 	return connection.NewPaginated(body, parameters, s.GetNetworkRulePortsPaginated), err
-}
-
-func (s *Service) getNetworkRulePortsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]NetworkRulePort], error) {
-	body := &connection.APIResponseBodyData[[]NetworkRulePort]{}
-
-	response, err := s.connection.Get("/ecloud/v2/network-rule-ports", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetNetworkRulePort retrieves a single rule by id
 func (s *Service) GetNetworkRulePort(ruleID string) (NetworkRulePort, error) {
-	body, err := s.getNetworkRulePortResponseBody(ruleID)
-
-	return body.Data, err
-}
-
-func (s *Service) getNetworkRulePortResponseBody(ruleID string) (*connection.APIResponseBodyData[NetworkRulePort], error) {
-	body := &connection.APIResponseBodyData[NetworkRulePort]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid network rule id")
+		return NetworkRulePort{}, fmt.Errorf("invalid network rule id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/network-rule-ports/%s", ruleID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkRulePortNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[NetworkRulePort](s.connection, fmt.Sprintf("/ecloud/v2/network-rule-ports/%s", ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&NetworkRulePortNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // CreateNetworkRulePort creates a new NetworkRulePort
 func (s *Service) CreateNetworkRulePort(req CreateNetworkRulePortRequest) (TaskReference, error) {
-	body, err := s.createNetworkRulePortResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/network-rule-ports", &req)
 	return body.Data, err
-}
-
-func (s *Service) createNetworkRulePortResponseBody(req CreateNetworkRulePortRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/network-rule-ports", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchNetworkRulePort patches a NetworkRulePort
 func (s *Service) PatchNetworkRulePort(ruleID string, req PatchNetworkRulePortRequest) (TaskReference, error) {
-	body, err := s.patchNetworkRulePortResponseBody(ruleID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchNetworkRulePortResponseBody(ruleID string, req PatchNetworkRulePortRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid network rule id")
+		return TaskReference{}, fmt.Errorf("invalid network rule id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/network-rule-ports/%s", ruleID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkRulePortNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/network-rule-ports/%s", ruleID), &req, connection.NotFoundResponseHandler(&NetworkRulePortNotFoundError{ID: ruleID}))
+	return body.Data, err
 }
 
 // DeleteNetworkRulePort deletes a NetworkRulePort
 func (s *Service) DeleteNetworkRulePort(ruleID string) (string, error) {
-	body, err := s.deleteNetworkRulePortResponseBody(ruleID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteNetworkRulePortResponseBody(ruleID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if ruleID == "" {
-		return body, fmt.Errorf("invalid network rule id")
+		return "", fmt.Errorf("invalid network rule id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/network-rule-ports/%s", ruleID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NetworkRulePortNotFoundError{ID: ruleID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/network-rule-ports/%s", ruleID), nil, connection.NotFoundResponseHandler(&NetworkRulePortNotFoundError{ID: ruleID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_nic.go
+++ b/pkg/service/ecloud/service_nic.go
@@ -13,47 +13,17 @@ func (s *Service) GetNICs(parameters connection.APIRequestParameters) ([]NIC, er
 
 // GetNICsPaginated retrieves a paginated list of nics
 func (s *Service) GetNICsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
-	body, err := s.getNICsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]NIC](s.connection, "/ecloud/v2/nics", parameters)
 	return connection.NewPaginated(body, parameters, s.GetNICsPaginated), err
-}
-
-func (s *Service) getNICsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]NIC], error) {
-	body := &connection.APIResponseBodyData[[]NIC]{}
-
-	response, err := s.connection.Get("/ecloud/v2/nics", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetNIC retrieves a single nic by id
 func (s *Service) GetNIC(nicID string) (NIC, error) {
-	body, err := s.getNICResponseBody(nicID)
-
-	return body.Data, err
-}
-
-func (s *Service) getNICResponseBody(nicID string) (*connection.APIResponseBodyData[NIC], error) {
-	body := &connection.APIResponseBodyData[NIC]{}
-
 	if nicID == "" {
-		return body, fmt.Errorf("invalid nic id")
+		return NIC{}, fmt.Errorf("invalid nic id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/nics/%s", nicID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NICNotFoundError{ID: nicID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[NIC](s.connection, fmt.Sprintf("/ecloud/v2/nics/%s", nicID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&NICNotFoundError{ID: nicID}))
+	return body.Data, err
 }
 
 // GetNICTasks retrieves a list of NIC tasks
@@ -65,32 +35,13 @@ func (s *Service) GetNICTasks(nicID string, parameters connection.APIRequestPara
 
 // GetNICTasksPaginated retrieves a paginated list of NIC tasks
 func (s *Service) GetNICTasksPaginated(nicID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getNICTasksPaginatedResponseBody(nicID, parameters)
-
+	if nicID == "" {
+		return nil, fmt.Errorf("invalid nic id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/nics/%s/tasks", nicID), parameters, connection.NotFoundResponseHandler(&NICNotFoundError{ID: nicID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetNICTasksPaginated(nicID, p)
 	}), err
-}
-
-func (s *Service) getNICTasksPaginatedResponseBody(nicID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if nicID == "" {
-		return body, fmt.Errorf("invalid nic id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/nics/%s/tasks", nicID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NICNotFoundError{ID: nicID}
-		}
-
-		return nil
-	})
 }
 
 // GetNICIPAddress retrieves a list of NIC IP addresses
@@ -102,163 +53,55 @@ func (s *Service) GetNICIPAddresses(nicID string, parameters connection.APIReque
 
 // GetNICIPAddressPaginated retrieves a paginated list of NIC IP addresses
 func (s *Service) GetNICIPAddressesPaginated(nicID string, parameters connection.APIRequestParameters) (*connection.Paginated[IPAddress], error) {
-	body, err := s.getNICIPAddressesPaginatedResponseBody(nicID, parameters)
-
+	if nicID == "" {
+		return nil, fmt.Errorf("invalid nic id")
+	}
+	body, err := connection.Get[[]IPAddress](s.connection, fmt.Sprintf("/ecloud/v2/nics/%s/ip-addresses", nicID), parameters, connection.NotFoundResponseHandler(&NICNotFoundError{ID: nicID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[IPAddress], error) {
 		return s.GetNICIPAddressesPaginated(nicID, p)
 	}), err
 }
 
-func (s *Service) getNICIPAddressesPaginatedResponseBody(nicID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]IPAddress], error) {
-	body := &connection.APIResponseBodyData[[]IPAddress]{}
-
-	if nicID == "" {
-		return body, fmt.Errorf("invalid nic id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/nics/%s/ip-addresses", nicID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NICNotFoundError{ID: nicID}
-		}
-
-		return nil
-	})
-}
-
 func (s *Service) AssignNICIPAddress(nicID string, req AssignIPAddressRequest) (string, error) {
-	body, err := s.assignNICIPAddressResponseBody(nicID, req)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) assignNICIPAddressResponseBody(nicID string, req AssignIPAddressRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if nicID == "" {
-		return body, fmt.Errorf("invalid nic id")
+		return "", fmt.Errorf("invalid nic id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/nics/%s/ip-addresses", nicID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NICNotFoundError{ID: nicID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/nics/%s/ip-addresses", nicID), &req, connection.NotFoundResponseHandler(&NICNotFoundError{ID: nicID}))
+	return body.Data.TaskID, err
 }
 
 // UnassignNICIPAddress unassigns an IP Address from a resource
 func (s *Service) UnassignNICIPAddress(nicID string, ipID string) (string, error) {
-	body, err := s.unassignNICIPAddressResponseBody(nicID, ipID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) unassignNICIPAddressResponseBody(nicID string, ipID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if nicID == "" {
-		return body, fmt.Errorf("invalid nic id")
+		return "", fmt.Errorf("invalid nic id")
 	}
-
 	if ipID == "" {
-		return body, fmt.Errorf("invalid ip address id")
+		return "", fmt.Errorf("invalid ip address id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/nics/%s/ip-addresses/%s", nicID, ipID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NICNotFoundError{ID: nicID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/nics/%s/ip-addresses/%s", nicID, ipID), nil, connection.NotFoundResponseHandler(&NICNotFoundError{ID: nicID}))
+	return body.Data.TaskID, err
 }
 
 // CreateNIC creates a new NIC
 func (s *Service) CreateNIC(req CreateNICRequest) (TaskReference, error) {
-	body, err := s.createNICResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/nics", &req)
 	return body.Data, err
-}
-
-func (s *Service) createNICResponseBody(req CreateNICRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/nics", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchNIC patches a NIC
 func (s *Service) PatchNIC(nicID string, req PatchNICRequest) (TaskReference, error) {
-	body, err := s.patchNICResponseBody(nicID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchNICResponseBody(nicID string, req PatchNICRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if nicID == "" {
-		return body, fmt.Errorf("invalid nic id")
+		return TaskReference{}, fmt.Errorf("invalid nic id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/nics/%s", nicID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NICNotFoundError{ID: nicID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/nics/%s", nicID), &req, connection.NotFoundResponseHandler(&NICNotFoundError{ID: nicID}))
+	return body.Data, err
 }
 
 // DeleteNIC deletes a NIC
 func (s *Service) DeleteNIC(NICID string) (string, error) {
-	body, err := s.deleteNICResponseBody(NICID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteNICResponseBody(NICID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if NICID == "" {
-		return body, fmt.Errorf("invalid nic id")
+		return "", fmt.Errorf("invalid nic id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/nics/%s", NICID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &NICNotFoundError{ID: NICID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/nics/%s", NICID), nil, connection.NotFoundResponseHandler(&NICNotFoundError{ID: NICID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_pod.go
+++ b/pkg/service/ecloud/service_pod.go
@@ -13,47 +13,17 @@ func (s *Service) GetPods(parameters connection.APIRequestParameters) ([]Pod, er
 
 // GetPodsPaginated retrieves a paginated list of pods
 func (s *Service) GetPodsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Pod], error) {
-	body, err := s.getPodsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Pod](s.connection, "/ecloud/v1/pods", parameters)
 	return connection.NewPaginated(body, parameters, s.GetPodsPaginated), err
-}
-
-func (s *Service) getPodsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Pod], error) {
-	body := &connection.APIResponseBodyData[[]Pod]{}
-
-	response, err := s.connection.Get("/ecloud/v1/pods", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetPod retrieves a single pod by ID
 func (s *Service) GetPod(podID int) (Pod, error) {
-	body, err := s.getPodResponseBody(podID)
-
-	return body.Data, err
-}
-
-func (s *Service) getPodResponseBody(podID int) (*connection.APIResponseBodyData[Pod], error) {
-	body := &connection.APIResponseBodyData[Pod]{}
-
 	if podID < 1 {
-		return body, fmt.Errorf("invalid pod id")
+		return Pod{}, fmt.Errorf("invalid pod id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/pods/%d", podID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &PodNotFoundError{ID: podID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Pod](s.connection, fmt.Sprintf("/ecloud/v1/pods/%d", podID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&PodNotFoundError{ID: podID}))
+	return body.Data, err
 }
 
 // GetPodTemplates retrieves a list of templates
@@ -65,118 +35,47 @@ func (s *Service) GetPodTemplates(podID int, parameters connection.APIRequestPar
 
 // GetPodTemplatesPaginated retrieves a paginated list of domains
 func (s *Service) GetPodTemplatesPaginated(podID int, parameters connection.APIRequestParameters) (*connection.Paginated[Template], error) {
-	body, err := s.getPodTemplatesPaginatedResponseBody(podID, parameters)
+	if podID < 1 {
+		return nil, fmt.Errorf("invalid pod id")
+	}
+	body, err := connection.Get[[]Template](s.connection, fmt.Sprintf("/ecloud/v1/pods/%d/templates", podID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Template], error) {
 		return s.GetPodTemplatesPaginated(podID, p)
 	}), err
 }
 
-func (s *Service) getPodTemplatesPaginatedResponseBody(podID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Template], error) {
-	body := &connection.APIResponseBodyData[[]Template]{}
-
-	if podID < 1 {
-		return body, fmt.Errorf("invalid pod id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/pods/%d/templates", podID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
-}
-
 // GetPodTemplate retrieves a single pod template by name
 func (s *Service) GetPodTemplate(podID int, templateName string) (Template, error) {
-	body, err := s.getPodTemplateResponseBody(podID, templateName)
-
-	return body.Data, err
-}
-
-func (s *Service) getPodTemplateResponseBody(podID int, templateName string) (*connection.APIResponseBodyData[Template], error) {
-	body := &connection.APIResponseBodyData[Template]{}
-
 	if podID < 1 {
-		return body, fmt.Errorf("invalid pod id")
+		return Template{}, fmt.Errorf("invalid pod id")
 	}
 	if templateName == "" {
-		return body, fmt.Errorf("invalid template name")
+		return Template{}, fmt.Errorf("invalid template name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/pods/%d/templates/%s", podID, templateName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{Name: templateName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Template](s.connection, fmt.Sprintf("/ecloud/v1/pods/%d/templates/%s", podID, templateName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TemplateNotFoundError{Name: templateName}))
+	return body.Data, err
 }
 
 // RenamePodTemplate renames a pod template
 func (s *Service) RenamePodTemplate(podID int, templateName string, req RenameTemplateRequest) error {
-	_, err := s.renamePodTemplateResponseBody(podID, templateName, req)
-
-	return err
-}
-
-func (s *Service) renamePodTemplateResponseBody(podID int, templateName string, req RenameTemplateRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if podID < 1 {
-		return body, fmt.Errorf("invalid pod id")
+		return fmt.Errorf("invalid pod id")
 	}
 	if templateName == "" {
-		return body, fmt.Errorf("invalid template name")
+		return fmt.Errorf("invalid template name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v1/pods/%d/templates/%s/move", podID, templateName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{Name: templateName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v1/pods/%d/templates/%s/move", podID, templateName), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TemplateNotFoundError{Name: templateName}))
 }
 
 // DeletePodTemplate removes a pod template
 func (s *Service) DeletePodTemplate(podID int, templateName string) error {
-	_, err := s.deletePodTemplateResponseBody(podID, templateName)
-
-	return err
-}
-
-func (s *Service) deletePodTemplateResponseBody(podID int, templateName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if podID < 1 {
-		return body, fmt.Errorf("invalid pod id")
+		return fmt.Errorf("invalid pod id")
 	}
 	if templateName == "" {
-		return body, fmt.Errorf("invalid template name")
+		return fmt.Errorf("invalid template name")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v1/pods/%d/templates/%s", podID, templateName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{Name: templateName}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v1/pods/%d/templates/%s", podID, templateName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TemplateNotFoundError{Name: templateName}))
 }
 
 // GetPodAppliances retrieves a list of appliances
@@ -188,46 +87,26 @@ func (s *Service) GetPodAppliances(podID int, parameters connection.APIRequestPa
 
 // GetPodAppliancesPaginated retrieves a paginated list of domains
 func (s *Service) GetPodAppliancesPaginated(podID int, parameters connection.APIRequestParameters) (*connection.Paginated[Appliance], error) {
-	body, err := s.getPodAppliancesPaginatedResponseBody(podID, parameters)
-
+	if podID < 1 {
+		return nil, fmt.Errorf("invalid pod id")
+	}
+	body, err := connection.Get[[]Appliance](s.connection, fmt.Sprintf("/ecloud/v1/pods/%d/appliances", podID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Appliance], error) {
 		return s.GetPodAppliancesPaginated(podID, p)
 	}), err
 }
 
-func (s *Service) getPodAppliancesPaginatedResponseBody(podID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Appliance], error) {
-	body := &connection.APIResponseBodyData[[]Appliance]{}
-
-	if podID < 1 {
-		return body, fmt.Errorf("invalid pod id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/pods/%d/appliances", podID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
-}
-
 // PodConsoleAvailable removes a pod template
 func (s *Service) PodConsoleAvailable(podID int) (bool, error) {
-	resp, err := s.podConsoleAvailableResponse(podID)
+	if podID < 1 {
+		return false, fmt.Errorf("invalid pod id")
+	}
+	resp, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/pods/%d/console-available", podID), connection.APIRequestParameters{})
 	if err != nil {
 		return false, err
 	}
-
 	if resp.StatusCode == 200 {
 		return true, nil
 	}
-
 	return false, nil
-}
-
-func (s *Service) podConsoleAvailableResponse(podID int) (*connection.APIResponse, error) {
-	if podID < 1 {
-		return &connection.APIResponse{}, fmt.Errorf("invalid pod id")
-	}
-
-	return s.connection.Get(fmt.Sprintf("/ecloud/v1/pods/%d/console-available", podID), connection.APIRequestParameters{})
 }

--- a/pkg/service/ecloud/service_region.go
+++ b/pkg/service/ecloud/service_region.go
@@ -13,45 +13,15 @@ func (s *Service) GetRegions(parameters connection.APIRequestParameters) ([]Regi
 
 // GetRegionsPaginated retrieves a paginated list of regions
 func (s *Service) GetRegionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Region], error) {
-	body, err := s.getRegionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Region](s.connection, "/ecloud/v2/regions", parameters)
 	return connection.NewPaginated(body, parameters, s.GetRegionsPaginated), err
-}
-
-func (s *Service) getRegionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Region], error) {
-	body := &connection.APIResponseBodyData[[]Region]{}
-
-	response, err := s.connection.Get("/ecloud/v2/regions", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetRegion retrieves a single region by id
 func (s *Service) GetRegion(regionID string) (Region, error) {
-	body, err := s.getRegionResponseBody(regionID)
-
-	return body.Data, err
-}
-
-func (s *Service) getRegionResponseBody(regionID string) (*connection.APIResponseBodyData[Region], error) {
-	body := &connection.APIResponseBodyData[Region]{}
-
 	if regionID == "" {
-		return body, fmt.Errorf("invalid region id")
+		return Region{}, fmt.Errorf("invalid region id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/regions/%s", regionID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RegionNotFoundError{ID: regionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Region](s.connection, fmt.Sprintf("/ecloud/v2/regions/%s", regionID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&RegionNotFoundError{ID: regionID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_resourcetier.go
+++ b/pkg/service/ecloud/service_resourcetier.go
@@ -13,45 +13,15 @@ func (s *Service) GetResourceTiers(parameters connection.APIRequestParameters) (
 
 // GetResourceTiersPaginated retrieves a paginated list of resource tiers
 func (s *Service) GetResourceTiersPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[ResourceTier], error) {
-	body, err := s.getResourceTiersPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]ResourceTier](s.connection, "/ecloud/v2/resource-tiers", parameters)
 	return connection.NewPaginated(body, parameters, s.GetResourceTiersPaginated), err
-}
-
-func (s *Service) getResourceTiersPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ResourceTier], error) {
-	body := &connection.APIResponseBodyData[[]ResourceTier]{}
-
-	response, err := s.connection.Get("/ecloud/v2/resource-tiers", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetResourceTier retrieves a single resource tier by id
 func (s *Service) GetResourceTier(tierID string) (ResourceTier, error) {
-	body, err := s.getResourceTierResponseBody(tierID)
-
-	return body.Data, err
-}
-
-func (s *Service) getResourceTierResponseBody(tierID string) (*connection.APIResponseBodyData[ResourceTier], error) {
-	body := &connection.APIResponseBodyData[ResourceTier]{}
-
 	if tierID == "" {
-		return body, fmt.Errorf("invalid resource tier id")
+		return ResourceTier{}, fmt.Errorf("invalid resource tier id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/resource-tiers/%s", tierID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ResourceTierNotFoundError{ID: tierID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[ResourceTier](s.connection, fmt.Sprintf("/ecloud/v2/resource-tiers/%s", tierID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ResourceTierNotFoundError{ID: tierID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_router.go
+++ b/pkg/service/ecloud/service_router.go
@@ -13,121 +13,39 @@ func (s *Service) GetRouters(parameters connection.APIRequestParameters) ([]Rout
 
 // GetRoutersPaginated retrieves a paginated list of routers
 func (s *Service) GetRoutersPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Router], error) {
-	body, err := s.getRoutersPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Router](s.connection, "/ecloud/v2/routers", parameters)
 	return connection.NewPaginated(body, parameters, s.GetRoutersPaginated), err
-}
-
-func (s *Service) getRoutersPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Router], error) {
-	body := &connection.APIResponseBodyData[[]Router]{}
-
-	response, err := s.connection.Get("/ecloud/v2/routers", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetRouter retrieves a single router by id
 func (s *Service) GetRouter(routerID string) (Router, error) {
-	body, err := s.getRouterResponseBody(routerID)
-
-	return body.Data, err
-}
-
-func (s *Service) getRouterResponseBody(routerID string) (*connection.APIResponseBodyData[Router], error) {
-	body := &connection.APIResponseBodyData[Router]{}
-
 	if routerID == "" {
-		return body, fmt.Errorf("invalid router id")
+		return Router{}, fmt.Errorf("invalid router id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/routers/%s", routerID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RouterNotFoundError{ID: routerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Router](s.connection, fmt.Sprintf("/ecloud/v2/routers/%s", routerID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
+	return body.Data, err
 }
 
 // CreateRouter creates a new Router
 func (s *Service) CreateRouter(req CreateRouterRequest) (string, error) {
-	body, err := s.createRouterResponseBody(req)
-
+	body, err := connection.Post[Router](s.connection, "/ecloud/v2/routers", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createRouterResponseBody(req CreateRouterRequest) (*connection.APIResponseBodyData[Router], error) {
-	body := &connection.APIResponseBodyData[Router]{}
-
-	response, err := s.connection.Post("/ecloud/v2/routers", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchRouter patches a Router
 func (s *Service) PatchRouter(routerID string, req PatchRouterRequest) error {
-	_, err := s.patchRouterResponseBody(routerID, req)
-
-	return err
-}
-
-func (s *Service) patchRouterResponseBody(routerID string, req PatchRouterRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if routerID == "" {
-		return body, fmt.Errorf("invalid router id")
+		return fmt.Errorf("invalid router id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/routers/%s", routerID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RouterNotFoundError{ID: routerID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ecloud/v2/routers/%s", routerID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
 }
 
 // DeleteRouter deletes a Router
 func (s *Service) DeleteRouter(routerID string) error {
-	_, err := s.deleteRouterResponseBody(routerID)
-
-	return err
-}
-
-func (s *Service) deleteRouterResponseBody(routerID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if routerID == "" {
-		return body, fmt.Errorf("invalid router id")
+		return fmt.Errorf("invalid router id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/routers/%s", routerID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RouterNotFoundError{ID: routerID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v2/routers/%s", routerID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
 }
 
 // GetRouterFirewallPolicies retrieves a list of firewall rule policies
@@ -139,32 +57,13 @@ func (s *Service) GetRouterFirewallPolicies(routerID string, parameters connecti
 
 // GetRouterFirewallPoliciesPaginated retrieves a paginated list of firewall rule policies
 func (s *Service) GetRouterFirewallPoliciesPaginated(routerID string, parameters connection.APIRequestParameters) (*connection.Paginated[FirewallPolicy], error) {
-	body, err := s.getRouterFirewallPoliciesPaginatedResponseBody(routerID, parameters)
-
+	if routerID == "" {
+		return nil, fmt.Errorf("invalid router id")
+	}
+	body, err := connection.Get[[]FirewallPolicy](s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/firewall-policies", routerID), parameters, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FirewallPolicy], error) {
 		return s.GetRouterFirewallPoliciesPaginated(routerID, p)
 	}), err
-}
-
-func (s *Service) getRouterFirewallPoliciesPaginatedResponseBody(routerID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]FirewallPolicy], error) {
-	body := &connection.APIResponseBodyData[[]FirewallPolicy]{}
-
-	if routerID == "" {
-		return body, fmt.Errorf("invalid router id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/routers/%s/firewall-policies", routerID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RouterNotFoundError{ID: routerID}
-		}
-
-		return nil
-	})
 }
 
 // GetRouterNetworks retrieves a list of router networks
@@ -176,32 +75,13 @@ func (s *Service) GetRouterNetworks(routerID string, parameters connection.APIRe
 
 // GetRouterNetworksPaginated retrieves a paginated list of router networks
 func (s *Service) GetRouterNetworksPaginated(routerID string, parameters connection.APIRequestParameters) (*connection.Paginated[Network], error) {
-	body, err := s.getRouterNetworksPaginatedResponseBody(routerID, parameters)
-
+	if routerID == "" {
+		return nil, fmt.Errorf("invalid router id")
+	}
+	body, err := connection.Get[[]Network](s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/networks", routerID), parameters, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Network], error) {
 		return s.GetRouterNetworksPaginated(routerID, p)
 	}), err
-}
-
-func (s *Service) getRouterNetworksPaginatedResponseBody(routerID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Network], error) {
-	body := &connection.APIResponseBodyData[[]Network]{}
-
-	if routerID == "" {
-		return body, fmt.Errorf("invalid router id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/routers/%s/networks", routerID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RouterNotFoundError{ID: routerID}
-		}
-
-		return nil
-	})
 }
 
 // GetRouterVPNs retrieves a list of router VPNs
@@ -213,60 +93,21 @@ func (s *Service) GetRouterVPNs(routerID string, parameters connection.APIReques
 
 // GetRouterVPNsPaginated retrieves a paginated list of router VPNs
 func (s *Service) GetRouterVPNsPaginated(routerID string, parameters connection.APIRequestParameters) (*connection.Paginated[VPN], error) {
-	body, err := s.getRouterVPNsPaginatedResponseBody(routerID, parameters)
-
+	if routerID == "" {
+		return nil, fmt.Errorf("invalid router id")
+	}
+	body, err := connection.Get[[]VPN](s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/vpns", routerID), parameters, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[VPN], error) {
 		return s.GetRouterVPNsPaginated(routerID, p)
 	}), err
 }
 
-func (s *Service) getRouterVPNsPaginatedResponseBody(routerID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VPN], error) {
-	body := &connection.APIResponseBodyData[[]VPN]{}
-
-	if routerID == "" {
-		return body, fmt.Errorf("invalid router id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/routers/%s/vpns", routerID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RouterNotFoundError{ID: routerID}
-		}
-
-		return nil
-	})
-}
-
 // DeployRouterDefaultFirewallPolicies deploys default firewall policy resources for specified router
 func (s *Service) DeployRouterDefaultFirewallPolicies(routerID string) error {
-	_, err := s.deployRouterDefaultFirewallPolicies(routerID)
-
-	return err
-}
-
-func (s *Service) deployRouterDefaultFirewallPolicies(routerID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if routerID == "" {
-		return body, fmt.Errorf("invalid router id")
+		return fmt.Errorf("invalid router id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/routers/%s/configure-default-policies", routerID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RouterNotFoundError{ID: routerID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/configure-default-policies", routerID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
 }
 
 // GetRouterTasks retrieves a list of Router tasks
@@ -278,30 +119,11 @@ func (s *Service) GetRouterTasks(routerID string, parameters connection.APIReque
 
 // GetRouterTasksPaginated retrieves a paginated list of Router tasks
 func (s *Service) GetRouterTasksPaginated(routerID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getRouterTasksPaginatedResponseBody(routerID, parameters)
-
+	if routerID == "" {
+		return nil, fmt.Errorf("invalid router id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/tasks", routerID), parameters, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetRouterTasksPaginated(routerID, p)
 	}), err
-}
-
-func (s *Service) getRouterTasksPaginatedResponseBody(routerID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if routerID == "" {
-		return body, fmt.Errorf("invalid router id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/routers/%s/tasks", routerID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RouterNotFoundError{ID: routerID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_routerthroughput.go
+++ b/pkg/service/ecloud/service_routerthroughput.go
@@ -13,45 +13,15 @@ func (s *Service) GetRouterThroughputs(parameters connection.APIRequestParameter
 
 // GetRouterThroughputsPaginated retrieves a paginated list of router throughputs
 func (s *Service) GetRouterThroughputsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[RouterThroughput], error) {
-	body, err := s.getRouterThroughputsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]RouterThroughput](s.connection, "/ecloud/v2/router-throughputs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetRouterThroughputsPaginated), err
-}
-
-func (s *Service) getRouterThroughputsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]RouterThroughput], error) {
-	body := &connection.APIResponseBodyData[[]RouterThroughput]{}
-
-	response, err := s.connection.Get("/ecloud/v2/router-throughputs", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetRouterThroughput retrieves a single router throughput by id
 func (s *Service) GetRouterThroughput(throughputID string) (RouterThroughput, error) {
-	body, err := s.getRouterThroughputResponseBody(throughputID)
-
-	return body.Data, err
-}
-
-func (s *Service) getRouterThroughputResponseBody(throughputID string) (*connection.APIResponseBodyData[RouterThroughput], error) {
-	body := &connection.APIResponseBodyData[RouterThroughput]{}
-
 	if throughputID == "" {
-		return body, fmt.Errorf("invalid router throughput id")
+		return RouterThroughput{}, fmt.Errorf("invalid router throughput id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/router-throughputs/%s", throughputID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RouterThroughputNotFoundError{ID: throughputID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[RouterThroughput](s.connection, fmt.Sprintf("/ecloud/v2/router-throughputs/%s", throughputID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&RouterThroughputNotFoundError{ID: throughputID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_site.go
+++ b/pkg/service/ecloud/service_site.go
@@ -13,45 +13,15 @@ func (s *Service) GetSites(parameters connection.APIRequestParameters) ([]Site, 
 
 // GetSitesPaginated retrieves a paginated list of sites
 func (s *Service) GetSitesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Site], error) {
-	body, err := s.getSitesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Site](s.connection, "/ecloud/v1/sites", parameters)
 	return connection.NewPaginated(body, parameters, s.GetSitesPaginated), err
-}
-
-func (s *Service) getSitesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Site], error) {
-	body := &connection.APIResponseBodyData[[]Site]{}
-
-	response, err := s.connection.Get("/ecloud/v1/sites", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetSite retrieves a single site by ID
 func (s *Service) GetSite(siteID int) (Site, error) {
-	body, err := s.getSiteResponseBody(siteID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSiteResponseBody(siteID int) (*connection.APIResponseBodyData[Site], error) {
-	body := &connection.APIResponseBodyData[Site]{}
-
 	if siteID < 1 {
-		return body, fmt.Errorf("invalid site id")
+		return Site{}, fmt.Errorf("invalid site id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/sites/%d", siteID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SiteNotFoundError{ID: siteID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Site](s.connection, fmt.Sprintf("/ecloud/v1/sites/%d", siteID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&SiteNotFoundError{ID: siteID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_solution.go
+++ b/pkg/service/ecloud/service_solution.go
@@ -13,75 +13,26 @@ func (s *Service) GetSolutions(parameters connection.APIRequestParameters) ([]So
 
 // GetSolutionsPaginated retrieves a paginated list of solutions
 func (s *Service) GetSolutionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Solution], error) {
-	body, err := s.getSolutionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Solution](s.connection, "/ecloud/v1/solutions", parameters)
 	return connection.NewPaginated(body, parameters, s.GetSolutionsPaginated), err
-}
-
-func (s *Service) getSolutionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Solution], error) {
-	body := &connection.APIResponseBodyData[[]Solution]{}
-
-	response, err := s.connection.Get("/ecloud/v1/solutions", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetSolution retrieves a single Solution by ID
 func (s *Service) GetSolution(solutionID int) (Solution, error) {
-	body, err := s.getSolutionResponseBody(solutionID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSolutionResponseBody(solutionID int) (*connection.APIResponseBodyData[Solution], error) {
-	body := &connection.APIResponseBodyData[Solution]{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return Solution{}, fmt.Errorf("invalid solution id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d", solutionID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Solution](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d", solutionID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
+	return body.Data, err
 }
 
 // PatchSolution patches an eCloud solution
 func (s *Service) PatchSolution(solutionID int, patch PatchSolutionRequest) (int, error) {
-	body, err := s.patchSolutionResponseBody(solutionID, patch)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) patchSolutionResponseBody(solutionID int, patch PatchSolutionRequest) (*connection.APIResponseBodyData[Solution], error) {
-	body := &connection.APIResponseBodyData[Solution]{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return 0, fmt.Errorf("invalid solution id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v1/solutions/%d", solutionID), &patch)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[Solution](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d", solutionID), &patch, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
+	return body.Data.ID, err
 }
 
 // GetSolutionVirtualMachines retrieves a list of vms
@@ -93,32 +44,13 @@ func (s *Service) GetSolutionVirtualMachines(solutionID int, parameters connecti
 
 // GetSolutionVirtualMachinesPaginated retrieves a paginated list of domains
 func (s *Service) GetSolutionVirtualMachinesPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[VirtualMachine], error) {
-	body, err := s.getSolutionVirtualMachinesPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID < 1 {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]VirtualMachine](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/vms", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[VirtualMachine], error) {
 		return s.GetSolutionVirtualMachinesPaginated(solutionID, p)
 	}), err
-}
-
-func (s *Service) getSolutionVirtualMachinesPaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VirtualMachine], error) {
-	body := &connection.APIResponseBodyData[[]VirtualMachine]{}
-
-	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/vms", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
 }
 
 // GetSolutionSites retrieves a list of sites
@@ -130,32 +62,13 @@ func (s *Service) GetSolutionSites(solutionID int, parameters connection.APIRequ
 
 // GetSolutionSitesPaginated retrieves a paginated list of domains
 func (s *Service) GetSolutionSitesPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[Site], error) {
-	body, err := s.getSolutionSitesPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID < 1 {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]Site](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/sites", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Site], error) {
 		return s.GetSolutionSitesPaginated(solutionID, p)
 	}), err
-}
-
-func (s *Service) getSolutionSitesPaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Site], error) {
-	body := &connection.APIResponseBodyData[[]Site]{}
-
-	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/sites", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
 }
 
 // GetSolutionDatastores retrieves a list of datastores
@@ -167,32 +80,13 @@ func (s *Service) GetSolutionDatastores(solutionID int, parameters connection.AP
 
 // GetSolutionDatastoresPaginated retrieves a paginated list of domains
 func (s *Service) GetSolutionDatastoresPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[Datastore], error) {
-	body, err := s.getSolutionDatastoresPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID < 1 {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]Datastore](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/datastores", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Datastore], error) {
 		return s.GetSolutionDatastoresPaginated(solutionID, p)
 	}), err
-}
-
-func (s *Service) getSolutionDatastoresPaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Datastore], error) {
-	body := &connection.APIResponseBodyData[[]Datastore]{}
-
-	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/datastores", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
 }
 
 // GetSolutionHosts retrieves a list of hosts
@@ -204,32 +98,13 @@ func (s *Service) GetSolutionHosts(solutionID int, parameters connection.APIRequ
 
 // GetSolutionHostsPaginated retrieves a paginated list of domains
 func (s *Service) GetSolutionHostsPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[V1Host], error) {
-	body, err := s.getSolutionHostsPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID < 1 {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]V1Host](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/hosts", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[V1Host], error) {
 		return s.GetSolutionHostsPaginated(solutionID, p)
 	}), err
-}
-
-func (s *Service) getSolutionHostsPaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]V1Host], error) {
-	body := &connection.APIResponseBodyData[[]V1Host]{}
-
-	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/hosts", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
 }
 
 // GetSolutionNetworks retrieves a list of networks
@@ -241,32 +116,13 @@ func (s *Service) GetSolutionNetworks(solutionID int, parameters connection.APIR
 
 // GetSolutionNetworksPaginated retrieves a paginated list of domains
 func (s *Service) GetSolutionNetworksPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[V1Network], error) {
-	body, err := s.getSolutionNetworksPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID < 1 {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]V1Network](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/networks", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[V1Network], error) {
 		return s.GetSolutionNetworksPaginated(solutionID, p)
 	}), err
-}
-
-func (s *Service) getSolutionNetworksPaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]V1Network], error) {
-	body := &connection.APIResponseBodyData[[]V1Network]{}
-
-	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/networks", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
 }
 
 // GetSolutionFirewalls retrieves a list of firewalls
@@ -278,32 +134,13 @@ func (s *Service) GetSolutionFirewalls(solutionID int, parameters connection.API
 
 // GetSolutionFirewallsPaginated retrieves a paginated list of domains
 func (s *Service) GetSolutionFirewallsPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[Firewall], error) {
-	body, err := s.getSolutionFirewallsPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID < 1 {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]Firewall](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/firewalls", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Firewall], error) {
 		return s.GetSolutionFirewallsPaginated(solutionID, p)
 	}), err
-}
-
-func (s *Service) getSolutionFirewallsPaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Firewall], error) {
-	body := &connection.APIResponseBodyData[[]Firewall]{}
-
-	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/firewalls", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
 }
 
 // GetSolutionTemplates retrieves a list of templates
@@ -315,125 +152,47 @@ func (s *Service) GetSolutionTemplates(solutionID int, parameters connection.API
 
 // GetSolutionTemplatesPaginated retrieves a paginated list of domains
 func (s *Service) GetSolutionTemplatesPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[Template], error) {
-	body, err := s.getSolutionTemplatesPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID < 1 {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]Template](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/templates", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Template], error) {
 		return s.GetSolutionTemplatesPaginated(solutionID, p)
 	}), err
 }
 
-func (s *Service) getSolutionTemplatesPaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Template], error) {
-	body := &connection.APIResponseBodyData[[]Template]{}
-
-	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/templates", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
-}
-
 // GetSolutionTemplate retrieves a single solution template by name
 func (s *Service) GetSolutionTemplate(solutionID int, templateName string) (Template, error) {
-	body, err := s.getSolutionTemplateResponseBody(solutionID, templateName)
-
-	return body.Data, err
-}
-
-func (s *Service) getSolutionTemplateResponseBody(solutionID int, templateName string) (*connection.APIResponseBodyData[Template], error) {
-	body := &connection.APIResponseBodyData[Template]{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return Template{}, fmt.Errorf("invalid solution id")
 	}
 	if templateName == "" {
-		return body, fmt.Errorf("invalid template name")
+		return Template{}, fmt.Errorf("invalid template name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/templates/%s", solutionID, templateName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{Name: templateName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Template](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/templates/%s", solutionID, templateName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TemplateNotFoundError{Name: templateName}))
+	return body.Data, err
 }
 
 // RenameSolutionTemplate renames a solution template
 func (s *Service) RenameSolutionTemplate(solutionID int, templateName string, req RenameTemplateRequest) error {
-	_, err := s.renameSolutionTemplateResponseBody(solutionID, templateName, req)
-
-	return err
-}
-
-func (s *Service) renameSolutionTemplateResponseBody(solutionID int, templateName string, req RenameTemplateRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
 	if templateName == "" {
-		return body, fmt.Errorf("invalid template name")
+		return fmt.Errorf("invalid template name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v1/solutions/%d/templates/%s/move", solutionID, templateName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{Name: templateName}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/templates/%s/move", solutionID, templateName), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TemplateNotFoundError{Name: templateName}))
 }
 
 // DeleteSolutionTemplate removes a solution template
 func (s *Service) DeleteSolutionTemplate(solutionID int, templateName string) error {
-	_, err := s.deleteSolutionTemplateResponseBody(solutionID, templateName)
-
-	return err
-}
-
-func (s *Service) deleteSolutionTemplateResponseBody(solutionID int, templateName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
 	if templateName == "" {
-		return body, fmt.Errorf("invalid template name")
+		return fmt.Errorf("invalid template name")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v1/solutions/%d/templates/%s", solutionID, templateName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{Name: templateName}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/templates/%s", solutionID, templateName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TemplateNotFoundError{Name: templateName}))
 }
 
 // GetSolutionTags retrieves a list of tags
@@ -445,150 +204,53 @@ func (s *Service) GetSolutionTags(solutionID int, parameters connection.APIReque
 
 // GetSolutionTagsPaginated retrieves a paginated list of v1 solution tags
 func (s *Service) GetSolutionTagsPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
-	body, err := s.getSolutionTagsV1PaginatedResponseBody(solutionID, parameters)
-
+	if solutionID < 1 {
+		return nil, fmt.Errorf("invalid solution id")
+	}
+	body, err := connection.Get[[]TagV1](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/tags", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
 		return s.GetSolutionTagsPaginated(solutionID, p)
 	}), err
 }
 
-func (s *Service) getSolutionTagsV1PaginatedResponseBody(solutionID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]TagV1], error) {
-	body := &connection.APIResponseBodyData[[]TagV1]{}
-
-	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/tags", solutionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
-}
-
 // GetSolutionTag retrieves a single solution v1 tag by key
 func (s *Service) GetSolutionTag(solutionID int, tagKey string) (TagV1, error) {
-	body, err := s.getSolutionTagV1ResponseBody(solutionID, tagKey)
-
-	return body.Data, err
-}
-
-func (s *Service) getSolutionTagV1ResponseBody(solutionID int, tagKey string) (*connection.APIResponseBodyData[TagV1], error) {
-	body := &connection.APIResponseBodyData[TagV1]{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return TagV1{}, fmt.Errorf("invalid solution id")
 	}
 	if tagKey == "" {
-		return body, fmt.Errorf("invalid tag key")
+		return TagV1{}, fmt.Errorf("invalid tag key")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/solutions/%d/tags/%s", solutionID, tagKey), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TagV1NotFoundError{Key: tagKey}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[TagV1](s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/tags/%s", solutionID, tagKey), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TagV1NotFoundError{Key: tagKey}))
+	return body.Data, err
 }
 
 // CreateSolutionTag creates a new solution v1 tag
 func (s *Service) CreateSolutionTag(solutionID int, req CreateTagV1Request) error {
-	_, err := s.createSolutionTagV1ResponseBody(solutionID, req)
-
-	return err
-}
-
-func (s *Service) createSolutionTagV1ResponseBody(solutionID int, req CreateTagV1Request) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v1/solutions/%d/tags", solutionID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/tags", solutionID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 }
 
 // PatchSolutionTag patches an eCloud solution v1 tag
 func (s *Service) PatchSolutionTag(solutionID int, tagKey string, patch PatchTagV1Request) error {
-	_, err := s.patchSolutionTagV1ResponseBody(solutionID, tagKey, patch)
-
-	return err
-}
-
-func (s *Service) patchSolutionTagV1ResponseBody(solutionID int, tagKey string, patch PatchTagV1Request) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
 	if tagKey == "" {
-		return body, fmt.Errorf("invalid tag key")
+		return fmt.Errorf("invalid tag key")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v1/solutions/%d/tags/%s", solutionID, tagKey), &patch)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TagV1NotFoundError{Key: tagKey}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/tags/%s", solutionID, tagKey), &patch, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TagV1NotFoundError{Key: tagKey}))
 }
 
 // DeleteSolutionTag removes a solution v1 tag
 func (s *Service) DeleteSolutionTag(solutionID int, tagKey string) error {
-	_, err := s.deleteSolutionTagV1ResponseBody(solutionID, tagKey)
-
-	return err
-}
-
-func (s *Service) deleteSolutionTagV1ResponseBody(solutionID int, tagKey string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return fmt.Errorf("invalid solution id")
 	}
 	if tagKey == "" {
-		return body, fmt.Errorf("invalid tag key")
+		return fmt.Errorf("invalid tag key")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v1/solutions/%d/tags/%s", solutionID, tagKey), nil)
-	if err != nil {
-		return body, err
-	}
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TagV1NotFoundError{Key: tagKey}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v1/solutions/%d/tags/%s", solutionID, tagKey), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TagV1NotFoundError{Key: tagKey}))
 }

--- a/pkg/service/ecloud/service_sshkeypair.go
+++ b/pkg/service/ecloud/service_sshkeypair.go
@@ -13,119 +13,37 @@ func (s *Service) GetSSHKeyPairs(parameters connection.APIRequestParameters) ([]
 
 // GetSSHKeyPairsPaginated retrieves a paginated list of keypairs
 func (s *Service) GetSSHKeyPairsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[SSHKeyPair], error) {
-	body, err := s.getSSHKeyPairsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]SSHKeyPair](s.connection, "/ecloud/v2/ssh-key-pairs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetSSHKeyPairsPaginated), err
-}
-
-func (s *Service) getSSHKeyPairsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]SSHKeyPair], error) {
-	body := &connection.APIResponseBodyData[[]SSHKeyPair]{}
-
-	response, err := s.connection.Get("/ecloud/v2/ssh-key-pairs", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetSSHKeyPair retrieves a single keypair by id
 func (s *Service) GetSSHKeyPair(keypairID string) (SSHKeyPair, error) {
-	body, err := s.getSSHKeyPairResponseBody(keypairID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSSHKeyPairResponseBody(keypairID string) (*connection.APIResponseBodyData[SSHKeyPair], error) {
-	body := &connection.APIResponseBodyData[SSHKeyPair]{}
-
 	if keypairID == "" {
-		return body, fmt.Errorf("invalid SSH key pair id")
+		return SSHKeyPair{}, fmt.Errorf("invalid SSH key pair id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/ssh-key-pairs/%s", keypairID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SSHKeyPairNotFoundError{ID: keypairID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[SSHKeyPair](s.connection, fmt.Sprintf("/ecloud/v2/ssh-key-pairs/%s", keypairID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&SSHKeyPairNotFoundError{ID: keypairID}))
+	return body.Data, err
 }
 
 // CreateSSHKeyPair creates a new SSHKeyPair
 func (s *Service) CreateSSHKeyPair(req CreateSSHKeyPairRequest) (string, error) {
-	body, err := s.createSSHKeyPairResponseBody(req)
-
+	body, err := connection.Post[SSHKeyPair](s.connection, "/ecloud/v2/ssh-key-pairs", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createSSHKeyPairResponseBody(req CreateSSHKeyPairRequest) (*connection.APIResponseBodyData[SSHKeyPair], error) {
-	body := &connection.APIResponseBodyData[SSHKeyPair]{}
-
-	response, err := s.connection.Post("/ecloud/v2/ssh-key-pairs", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchSSHKeyPair patches a SSHKeyPair
 func (s *Service) PatchSSHKeyPair(keypairID string, req PatchSSHKeyPairRequest) error {
-	_, err := s.patchSSHKeyPairResponseBody(keypairID, req)
-
-	return err
-}
-
-func (s *Service) patchSSHKeyPairResponseBody(keypairID string, req PatchSSHKeyPairRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if keypairID == "" {
-		return body, fmt.Errorf("invalid SSH key pair id")
+		return fmt.Errorf("invalid SSH key pair id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/ssh-key-pairs/%s", keypairID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SSHKeyPairNotFoundError{ID: keypairID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ecloud/v2/ssh-key-pairs/%s", keypairID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&SSHKeyPairNotFoundError{ID: keypairID}))
 }
 
 // DeleteSSHKeyPair deletes a SSHKeyPair
 func (s *Service) DeleteSSHKeyPair(keypairID string) error {
-	_, err := s.deleteSSHKeyPairResponseBody(keypairID)
-
-	return err
-}
-
-func (s *Service) deleteSSHKeyPairResponseBody(keypairID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if keypairID == "" {
-		return body, fmt.Errorf("invalid SSH key pair id")
+		return fmt.Errorf("invalid SSH key pair id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/ssh-key-pairs/%s", keypairID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SSHKeyPairNotFoundError{ID: keypairID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v2/ssh-key-pairs/%s", keypairID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&SSHKeyPairNotFoundError{ID: keypairID}))
 }

--- a/pkg/service/ecloud/service_tags.go
+++ b/pkg/service/ecloud/service_tags.go
@@ -13,119 +13,37 @@ func (s *Service) GetTags(parameters connection.APIRequestParameters) ([]Tag, er
 
 // GetTagsPaginated retrieves a paginated list of tags
 func (s *Service) GetTagsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Tag], error) {
-	body, err := s.getTagsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Tag](s.connection, "/ecloud/v2/tags", parameters)
 	return connection.NewPaginated(body, parameters, s.GetTagsPaginated), err
-}
-
-func (s *Service) getTagsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Tag], error) {
-	body := &connection.APIResponseBodyData[[]Tag]{}
-
-	response, err := s.connection.Get("/ecloud/v2/tags", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetTag retrieves a single tag by id
 func (s *Service) GetTag(tagID string) (Tag, error) {
-	body, err := s.getTagResponseBody(tagID)
-
-	return body.Data, err
-}
-
-func (s *Service) getTagResponseBody(tagID string) (*connection.APIResponseBodyData[Tag], error) {
-	body := &connection.APIResponseBodyData[Tag]{}
-
 	if tagID == "" {
-		return body, fmt.Errorf("ecloud: invalid tag id")
+		return Tag{}, fmt.Errorf("ecloud: invalid tag id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/tags/%s", tagID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TagNotFoundError{ID: tagID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Tag](s.connection, fmt.Sprintf("/ecloud/v2/tags/%s", tagID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TagNotFoundError{ID: tagID}))
+	return body.Data, err
 }
 
 // CreateTag creates a new tag
 func (s *Service) CreateTag(req CreateTagRequest) (string, error) {
-	body, err := s.createTagResponseBody(req)
-
+	body, err := connection.Post[Tag](s.connection, "/ecloud/v2/tags", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createTagResponseBody(req CreateTagRequest) (*connection.APIResponseBodyData[Tag], error) {
-	body := &connection.APIResponseBodyData[Tag]{}
-
-	response, err := s.connection.Post("/ecloud/v2/tags", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchTag patches a tag
 func (s *Service) PatchTag(tagID string, req PatchTagRequest) error {
-	_, err := s.patchTagResponseBody(tagID, req)
-
-	return err
-}
-
-func (s *Service) patchTagResponseBody(tagID string, req PatchTagRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if tagID == "" {
-		return body, fmt.Errorf("ecloud: invalid tag id")
+		return fmt.Errorf("ecloud: invalid tag id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/tags/%s", tagID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TagNotFoundError{ID: tagID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ecloud/v2/tags/%s", tagID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TagNotFoundError{ID: tagID}))
 }
 
 // DeleteTag removes a tag
 func (s *Service) DeleteTag(tagID string) error {
-	_, err := s.deleteTagResponseBody(tagID)
-
-	return err
-}
-
-func (s *Service) deleteTagResponseBody(tagID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if tagID == "" {
-		return body, fmt.Errorf("ecloud: invalid tag id")
+		return fmt.Errorf("ecloud: invalid tag id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/tags/%s", tagID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TagNotFoundError{ID: tagID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v2/tags/%s", tagID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TagNotFoundError{ID: tagID}))
 }

--- a/pkg/service/ecloud/service_task.go
+++ b/pkg/service/ecloud/service_task.go
@@ -13,45 +13,15 @@ func (s *Service) GetTasks(parameters connection.APIRequestParameters) ([]Task, 
 
 // GetTasksPaginated retrieves a paginated list of tasks
 func (s *Service) GetTasksPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getTasksPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Task](s.connection, "/ecloud/v2/tasks", parameters)
 	return connection.NewPaginated(body, parameters, s.GetTasksPaginated), err
-}
-
-func (s *Service) getTasksPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	response, err := s.connection.Get("/ecloud/v2/tasks", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetTask retrieves a single task by id
 func (s *Service) GetTask(taskID string) (Task, error) {
-	body, err := s.getTaskResponseBody(taskID)
-
-	return body.Data, err
-}
-
-func (s *Service) getTaskResponseBody(taskID string) (*connection.APIResponseBodyData[Task], error) {
-	body := &connection.APIResponseBodyData[Task]{}
-
 	if taskID == "" {
-		return body, fmt.Errorf("invalid task id")
+		return Task{}, fmt.Errorf("invalid task id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/tasks/%s", taskID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TaskNotFoundError{ID: taskID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Task](s.connection, fmt.Sprintf("/ecloud/v2/tasks/%s", taskID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TaskNotFoundError{ID: taskID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_v1host.go
+++ b/pkg/service/ecloud/service_v1host.go
@@ -13,45 +13,15 @@ func (s *Service) GetV1Hosts(parameters connection.APIRequestParameters) ([]V1Ho
 
 // GetV1HostsPaginated retrieves a paginated list of v1 hosts
 func (s *Service) GetV1HostsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[V1Host], error) {
-	body, err := s.getV1HostsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]V1Host](s.connection, "/ecloud/v1/hosts", parameters)
 	return connection.NewPaginated(body, parameters, s.GetV1HostsPaginated), err
-}
-
-func (s *Service) getV1HostsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]V1Host], error) {
-	body := &connection.APIResponseBodyData[[]V1Host]{}
-
-	response, err := s.connection.Get("/ecloud/v1/hosts", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetV1Host retrieves a single v1 host by ID
 func (s *Service) GetV1Host(hostID int) (V1Host, error) {
-	body, err := s.getV1HostResponseBody(hostID)
-
-	return body.Data, err
-}
-
-func (s *Service) getV1HostResponseBody(hostID int) (*connection.APIResponseBodyData[V1Host], error) {
-	body := &connection.APIResponseBodyData[V1Host]{}
-
 	if hostID < 1 {
-		return body, fmt.Errorf("invalid host id")
+		return V1Host{}, fmt.Errorf("invalid host id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/hosts/%d", hostID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &V1HostNotFoundError{ID: hostID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[V1Host](s.connection, fmt.Sprintf("/ecloud/v1/hosts/%d", hostID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&V1HostNotFoundError{ID: hostID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_vip.go
+++ b/pkg/service/ecloud/service_vip.go
@@ -13,119 +13,39 @@ func (s *Service) GetVIPs(parameters connection.APIRequestParameters) ([]VIP, er
 
 // GetVIPsPaginated retrieves a paginated list of vips
 func (s *Service) GetVIPsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VIP], error) {
-	body, err := s.getVIPsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VIP](s.connection, "/ecloud/v2/vips", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVIPsPaginated), err
-}
-
-func (s *Service) getVIPsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VIP], error) {
-	body := &connection.APIResponseBodyData[[]VIP]{}
-
-	response, err := s.connection.Get("/ecloud/v2/vips", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVIP retrieves a single vip by id
 func (s *Service) GetVIP(vipID string) (VIP, error) {
-	body, err := s.getVIPResponseBody(vipID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVIPResponseBody(vipID string) (*connection.APIResponseBodyData[VIP], error) {
-	body := &connection.APIResponseBodyData[VIP]{}
-
 	if vipID == "" {
-		return body, fmt.Errorf("invalid vip id")
+		return VIP{}, fmt.Errorf("invalid vip id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vips/%s", vipID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VIPNotFoundError{ID: vipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VIP](s.connection, fmt.Sprintf("/ecloud/v2/vips/%s", vipID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VIPNotFoundError{ID: vipID}))
+	return body.Data, err
 }
 
 // CreateVIP creates a new VIP
 func (s *Service) CreateVIP(req CreateVIPRequest) (TaskReference, error) {
-	body, err := s.createVIPResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/vips", &req)
 	return body.Data, err
-}
-
-func (s *Service) createVIPResponseBody(req CreateVIPRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/vips", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVIP patches a VIP
 func (s *Service) PatchVIP(vipID string, req PatchVIPRequest) (TaskReference, error) {
-	body, err := s.patchVIPResponseBody(vipID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchVIPResponseBody(vipID string, req PatchVIPRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if vipID == "" {
-		return body, fmt.Errorf("invalid vip id")
+		return TaskReference{}, fmt.Errorf("invalid vip id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/vips/%s", vipID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VIPNotFoundError{ID: vipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vips/%s", vipID), &req, connection.NotFoundResponseHandler(&VIPNotFoundError{ID: vipID}))
+	return body.Data, err
 }
 
 // DeleteVIP deletes a VIP
 func (s *Service) DeleteVIP(vipID string) (string, error) {
-	body, err := s.deleteVIPResponseBody(vipID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteVIPResponseBody(vipID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if vipID == "" {
-		return body, fmt.Errorf("invalid vip id")
+		return "", fmt.Errorf("invalid vip id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/vips/%s", vipID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VIPNotFoundError{ID: vipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vips/%s", vipID), nil, connection.NotFoundResponseHandler(&VIPNotFoundError{ID: vipID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_virtualmachine.go
+++ b/pkg/service/ecloud/service_virtualmachine.go
@@ -13,317 +13,96 @@ func (s *Service) GetVirtualMachines(parameters connection.APIRequestParameters)
 
 // GetVirtualMachinesPaginated retrieves a paginated list of vms
 func (s *Service) GetVirtualMachinesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VirtualMachine], error) {
-	body, err := s.getVirtualMachinesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VirtualMachine](s.connection, "/ecloud/v1/vms", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVirtualMachinesPaginated), err
-}
-
-func (s *Service) getVirtualMachinesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VirtualMachine], error) {
-	body := &connection.APIResponseBodyData[[]VirtualMachine]{}
-
-	response, err := s.connection.Get("/ecloud/v1/vms", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVirtualMachine retrieves a single virtual machine by ID
 func (s *Service) GetVirtualMachine(vmID int) (VirtualMachine, error) {
-	body, err := s.getVirtualMachineResponseBody(vmID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVirtualMachineResponseBody(vmID int) (*connection.APIResponseBodyData[VirtualMachine], error) {
-	body := &connection.APIResponseBodyData[VirtualMachine]{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return VirtualMachine{}, fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/vms/%d", vmID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VirtualMachine](s.connection, fmt.Sprintf("/ecloud/v1/vms/%d", vmID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
+	return body.Data, err
 }
 
 // DeleteVirtualMachine removes a virtual machine
 func (s *Service) DeleteVirtualMachine(vmID int) error {
-	_, err := s.deleteVirtualMachineResponseBody(vmID)
-
-	return err
-}
-
-func (s *Service) deleteVirtualMachineResponseBody(vmID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v1/vms/%d", vmID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d", vmID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 }
 
 // CreateVirtualMachine creates a new virtual machine
 func (s *Service) CreateVirtualMachine(req CreateVirtualMachineRequest) (int, error) {
-	body, err := s.createVirtualMachineResponseBody(req)
-
+	body, err := connection.Post[VirtualMachine](s.connection, "/ecloud/v1/vms", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createVirtualMachineResponseBody(req CreateVirtualMachineRequest) (*connection.APIResponseBodyData[VirtualMachine], error) {
-	body := &connection.APIResponseBodyData[VirtualMachine]{}
-
-	response, err := s.connection.Post("/ecloud/v1/vms", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVirtualMachine patches an eCloud virtual machine
 func (s *Service) PatchVirtualMachine(vmID int, patch PatchVirtualMachineRequest) error {
-	_, err := s.patchVirtualMachineResponseBody(vmID, patch)
-
-	return err
-}
-
-func (s *Service) patchVirtualMachineResponseBody(vmID int, patch PatchVirtualMachineRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v1/vms/%d", vmID), &patch)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d", vmID), &patch, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 }
 
 // CloneVirtualMachine clones a virtual machine
 func (s *Service) CloneVirtualMachine(vmID int, req CloneVirtualMachineRequest) (int, error) {
-	body, err := s.cloneVirtualMachineResponseBody(vmID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) cloneVirtualMachineResponseBody(vmID int, req CloneVirtualMachineRequest) (*connection.APIResponseBodyData[VirtualMachine], error) {
-	body := &connection.APIResponseBodyData[VirtualMachine]{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return 0, fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v1/vms/%d/clone", vmID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[VirtualMachine](s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/clone", vmID), &req, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
+	return body.Data.ID, err
 }
 
 // PowerOnVirtualMachine powers on a virtual machine
 func (s *Service) PowerOnVirtualMachine(vmID int) error {
-	_, err := s.powerOnVirtualMachineResponseBody(vmID)
-
-	return err
-}
-
-func (s *Service) powerOnVirtualMachineResponseBody(vmID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v1/vms/%d/power-on", vmID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	return connection.PutRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/power-on", vmID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 }
 
 // PowerOffVirtualMachine powers off a virtual machine
 func (s *Service) PowerOffVirtualMachine(vmID int) error {
-	_, err := s.powerOffVirtualMachineResponseBody(vmID)
-
-	return err
-}
-
-func (s *Service) powerOffVirtualMachineResponseBody(vmID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v1/vms/%d/power-off", vmID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	return connection.PutRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/power-off", vmID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 }
 
 // PowerResetVirtualMachine resets a virtual machine (hard power off)
 func (s *Service) PowerResetVirtualMachine(vmID int) error {
-	_, err := s.powerResetVirtualMachineResponseBody(vmID)
-
-	return err
-}
-
-func (s *Service) powerResetVirtualMachineResponseBody(vmID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v1/vms/%d/power-reset", vmID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	return connection.PutRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/power-reset", vmID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 }
 
 // PowerShutdownVirtualMachine shuts down a virtual machine
 func (s *Service) PowerShutdownVirtualMachine(vmID int) error {
-	_, err := s.powerShutdownVirtualMachineResponseBody(vmID)
-
-	return err
-}
-
-func (s *Service) powerShutdownVirtualMachineResponseBody(vmID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v1/vms/%d/power-shutdown", vmID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	return connection.PutRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/power-shutdown", vmID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 }
 
 // PowerRestartVirtualMachine resets a virtual machine (graceful power off)
 func (s *Service) PowerRestartVirtualMachine(vmID int) error {
-	_, err := s.powerRestartVirtualMachineResponseBody(vmID)
-
-	return err
-}
-
-func (s *Service) powerRestartVirtualMachineResponseBody(vmID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v1/vms/%d/power-restart", vmID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	return connection.PutRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/power-restart", vmID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 }
 
 // CreateVirtualMachineTemplate creates a virtual machine template
 func (s *Service) CreateVirtualMachineTemplate(vmID int, req CreateVirtualMachineTemplateRequest) error {
-	_, err := s.createVirtualMachineTemplateResponseBody(vmID, req)
-
-	return err
-}
-
-func (s *Service) createVirtualMachineTemplateResponseBody(vmID int, req CreateVirtualMachineTemplateRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v1/vms/%d/clone-to-template", vmID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/clone-to-template", vmID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 }
 
 // GetVirtualMachineTags retrieves a list of tags
@@ -335,179 +114,62 @@ func (s *Service) GetVirtualMachineTags(vmID int, parameters connection.APIReque
 
 // GetVirtualMachineTagsPaginated retrieves a paginated list of v1 virtual machine tags
 func (s *Service) GetVirtualMachineTagsPaginated(vmID int, parameters connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
-	body, err := s.getVirtualMachineTagsV1PaginatedResponseBody(vmID, parameters)
-
+	if vmID < 1 {
+		return nil, fmt.Errorf("invalid virtual machine id")
+	}
+	body, err := connection.Get[[]TagV1](s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/tags", vmID), parameters, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[TagV1], error) {
 		return s.GetVirtualMachineTagsPaginated(vmID, p)
 	}), err
 }
 
-func (s *Service) getVirtualMachineTagsV1PaginatedResponseBody(vmID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]TagV1], error) {
-	body := &connection.APIResponseBodyData[[]TagV1]{}
-
-	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/vms/%d/tags", vmID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
-}
-
 // GetVirtualMachineTag retrieves a single virtual machine v1 tag by key
 func (s *Service) GetVirtualMachineTag(vmID int, tagKey string) (TagV1, error) {
-	body, err := s.getVirtualMachineTagV1ResponseBody(vmID, tagKey)
-
-	return body.Data, err
-}
-
-func (s *Service) getVirtualMachineTagV1ResponseBody(vmID int, tagKey string) (*connection.APIResponseBodyData[TagV1], error) {
-	body := &connection.APIResponseBodyData[TagV1]{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return TagV1{}, fmt.Errorf("invalid virtual machine id")
 	}
 	if tagKey == "" {
-		return body, fmt.Errorf("invalid tag key")
+		return TagV1{}, fmt.Errorf("invalid tag key")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v1/vms/%d/tags/%s", vmID, tagKey), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TagV1NotFoundError{Key: tagKey}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[TagV1](s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/tags/%s", vmID, tagKey), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TagV1NotFoundError{Key: tagKey}))
+	return body.Data, err
 }
 
 // CreateVirtualMachineTag creates a new virtual machine v1 tag
 func (s *Service) CreateVirtualMachineTag(vmID int, req CreateTagV1Request) error {
-	_, err := s.createVirtualMachineTagV1ResponseBody(vmID, req)
-
-	return err
-}
-
-func (s *Service) createVirtualMachineTagV1ResponseBody(vmID int, req CreateTagV1Request) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v1/vms/%d/tags", vmID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/tags", vmID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
 }
 
 // PatchVirtualMachineTag patches an eCloud virtual machine v1 tag
 func (s *Service) PatchVirtualMachineTag(vmID int, tagKey string, patch PatchTagV1Request) error {
-	_, err := s.patchVirtualMachineTagV1ResponseBody(vmID, tagKey, patch)
-
-	return err
-}
-
-func (s *Service) patchVirtualMachineTagV1ResponseBody(vmID int, tagKey string, patch PatchTagV1Request) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
 	if tagKey == "" {
-		return body, fmt.Errorf("invalid tag key")
+		return fmt.Errorf("invalid tag key")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v1/vms/%d/tags/%s", vmID, tagKey), &patch)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TagV1NotFoundError{Key: tagKey}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/tags/%s", vmID, tagKey), &patch, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TagV1NotFoundError{Key: tagKey}))
 }
 
 // DeleteVirtualMachineTag removes a virtual machine v1 tag
 func (s *Service) DeleteVirtualMachineTag(vmID int, tagKey string) error {
-	_, err := s.deleteVirtualMachineTagV1ResponseBody(vmID, tagKey)
-
-	return err
-}
-
-func (s *Service) deleteVirtualMachineTagV1ResponseBody(vmID int, tagKey string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return fmt.Errorf("invalid virtual machine id")
 	}
 	if tagKey == "" {
-		return body, fmt.Errorf("invalid tag key")
+		return fmt.Errorf("invalid tag key")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v1/vms/%d/tags/%s", vmID, tagKey), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TagV1NotFoundError{Key: tagKey}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/tags/%s", vmID, tagKey), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TagV1NotFoundError{Key: tagKey}))
 }
 
 // CreateVirtualMachineConsoleSession creates a virtual machine console session
 func (s *Service) CreateVirtualMachineConsoleSession(vmID int) (ConsoleSession, error) {
-	body, err := s.createVirtualMachineConsoleSessionResponseBody(vmID)
-
-	return body.Data, err
-}
-
-func (s *Service) createVirtualMachineConsoleSessionResponseBody(vmID int) (*connection.APIResponseBodyData[ConsoleSession], error) {
-	body := &connection.APIResponseBodyData[ConsoleSession]{}
-
 	if vmID < 1 {
-		return body, fmt.Errorf("invalid virtual machine id")
+		return ConsoleSession{}, fmt.Errorf("invalid virtual machine id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v1/vms/%d/console-session", vmID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VirtualMachineNotFoundError{ID: vmID}
-		}
-
-		return nil
-	})
+	body, err := connection.Put[ConsoleSession](s.connection, fmt.Sprintf("/ecloud/v1/vms/%d/console-session", vmID), nil, connection.NotFoundResponseHandler(&VirtualMachineNotFoundError{ID: vmID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_volume.go
+++ b/pkg/service/ecloud/service_volume.go
@@ -13,121 +13,41 @@ func (s *Service) GetVolumes(parameters connection.APIRequestParameters) ([]Volu
 
 // GetVolumesPaginated retrieves a paginated list of volumes
 func (s *Service) GetVolumesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-	body, err := s.getVolumesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Volume](s.connection, "/ecloud/v2/volumes", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVolumesPaginated), err
-}
-
-func (s *Service) getVolumesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Volume], error) {
-	body := &connection.APIResponseBodyData[[]Volume]{}
-
-	response, err := s.connection.Get("/ecloud/v2/volumes", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVolume retrieves a single volume by id
 func (s *Service) GetVolume(volumeID string) (Volume, error) {
-	body, err := s.getVolumeResponseBody(volumeID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVolumeResponseBody(volumeID string) (*connection.APIResponseBodyData[Volume], error) {
-	body := &connection.APIResponseBodyData[Volume]{}
-
 	if volumeID == "" {
-		return body, fmt.Errorf("invalid volume id")
+		return Volume{}, fmt.Errorf("invalid volume id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/volumes/%s", volumeID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeNotFoundError{ID: volumeID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Volume](s.connection, fmt.Sprintf("/ecloud/v2/volumes/%s", volumeID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VolumeNotFoundError{ID: volumeID}))
+	return body.Data, err
 }
 
 // CreateVolume creates a volume
 func (s *Service) CreateVolume(req CreateVolumeRequest) (TaskReference, error) {
-	body, err := s.createVolumeResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/volumes", &req)
 	return body.Data, err
-}
-
-func (s *Service) createVolumeResponseBody(req CreateVolumeRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/volumes", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVolume patches a Volume
 func (s *Service) PatchVolume(volumeID string, req PatchVolumeRequest) (TaskReference, error) {
-	body, err := s.patchVolumeResponseBody(volumeID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchVolumeResponseBody(volumeID string, req PatchVolumeRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if volumeID == "" {
-		return body, fmt.Errorf("invalid volume id")
+		return TaskReference{}, fmt.Errorf("invalid volume id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/volumes/%s", volumeID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeNotFoundError{ID: volumeID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/volumes/%s", volumeID), &req, connection.NotFoundResponseHandler(&VolumeNotFoundError{ID: volumeID}))
+	return body.Data, err
 }
 
 // DeleteVolume deletes a Volume
 func (s *Service) DeleteVolume(volumeID string) (string, error) {
-	body, err := s.deleteVolumeResponseBody(volumeID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteVolumeResponseBody(volumeID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if volumeID == "" {
-		return body, fmt.Errorf("invalid volume id")
+		return "", fmt.Errorf("invalid volume id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/volumes/%s", volumeID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeNotFoundError{ID: volumeID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/volumes/%s", volumeID), nil, connection.NotFoundResponseHandler(&VolumeNotFoundError{ID: volumeID}))
+	return body.Data.TaskID, err
 }
 
 // GetVolumeInstances retrieves a list of volume instances
@@ -139,32 +59,13 @@ func (s *Service) GetVolumeInstances(volumeID string, parameters connection.APIR
 
 // GetVolumeInstancesPaginated retrieves a paginated list of volume instances
 func (s *Service) GetVolumeInstancesPaginated(volumeID string, parameters connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
-	body, err := s.getVolumeInstancesPaginatedResponseBody(volumeID, parameters)
-
+	if volumeID == "" {
+		return nil, fmt.Errorf("invalid volume id")
+	}
+	body, err := connection.Get[[]Instance](s.connection, fmt.Sprintf("/ecloud/v2/volumes/%s/instances", volumeID), parameters, connection.NotFoundResponseHandler(&VolumeNotFoundError{ID: volumeID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
 		return s.GetVolumeInstancesPaginated(volumeID, p)
 	}), err
-}
-
-func (s *Service) getVolumeInstancesPaginatedResponseBody(volumeID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Instance], error) {
-	body := &connection.APIResponseBodyData[[]Instance]{}
-
-	if volumeID == "" {
-		return body, fmt.Errorf("invalid volume id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/volumes/%s/instances", volumeID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeNotFoundError{ID: volumeID}
-		}
-
-		return nil
-	})
 }
 
 // GetVolumeTasks retrieves a list of Volume tasks
@@ -176,30 +77,11 @@ func (s *Service) GetVolumeTasks(volumeID string, parameters connection.APIReque
 
 // GetVolumeTasksPaginated retrieves a paginated list of Volume tasks
 func (s *Service) GetVolumeTasksPaginated(volumeID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getVolumeTasksPaginatedResponseBody(volumeID, parameters)
-
+	if volumeID == "" {
+		return nil, fmt.Errorf("invalid volume id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/volumes/%s/tasks", volumeID), parameters, connection.NotFoundResponseHandler(&VolumeNotFoundError{ID: volumeID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetVolumeTasksPaginated(volumeID, p)
 	}), err
-}
-
-func (s *Service) getVolumeTasksPaginatedResponseBody(volumeID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if volumeID == "" {
-		return body, fmt.Errorf("invalid volume id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/volumes/%s/tasks", volumeID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeNotFoundError{ID: volumeID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_volumegroup.go
+++ b/pkg/service/ecloud/service_volumegroup.go
@@ -13,121 +13,41 @@ func (s *Service) GetVolumeGroups(parameters connection.APIRequestParameters) ([
 
 // GetVolumeGroupsPaginated retrieves a paginated list of volume groups
 func (s *Service) GetVolumeGroupsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VolumeGroup], error) {
-	body, err := s.getVolumeGroupsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VolumeGroup](s.connection, "/ecloud/v2/volume-groups", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVolumeGroupsPaginated), err
-}
-
-func (s *Service) getVolumeGroupsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VolumeGroup], error) {
-	body := &connection.APIResponseBodyData[[]VolumeGroup]{}
-
-	response, err := s.connection.Get("/ecloud/v2/volume-groups", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVolumeGroup retrieves a single volumeGroup by id
 func (s *Service) GetVolumeGroup(volumeGroupID string) (VolumeGroup, error) {
-	body, err := s.getVolumeGroupResponseBody(volumeGroupID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVolumeGroupResponseBody(volumeGroupID string) (*connection.APIResponseBodyData[VolumeGroup], error) {
-	body := &connection.APIResponseBodyData[VolumeGroup]{}
-
 	if volumeGroupID == "" {
-		return body, fmt.Errorf("invalid volume group id")
+		return VolumeGroup{}, fmt.Errorf("invalid volume group id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/volume-groups/%s", volumeGroupID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeGroupNotFoundError{ID: volumeGroupID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VolumeGroup](s.connection, fmt.Sprintf("/ecloud/v2/volume-groups/%s", volumeGroupID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VolumeGroupNotFoundError{ID: volumeGroupID}))
+	return body.Data, err
 }
 
 // CreateVolumeGroup creates a volumeGroup
 func (s *Service) CreateVolumeGroup(req CreateVolumeGroupRequest) (TaskReference, error) {
-	body, err := s.createVolumeGroupResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/volume-groups", &req)
 	return body.Data, err
-}
-
-func (s *Service) createVolumeGroupResponseBody(req CreateVolumeGroupRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/volume-groups", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVolumeGroup patches a volumeGroup
 func (s *Service) PatchVolumeGroup(volumeGroupID string, req PatchVolumeGroupRequest) (TaskReference, error) {
-	body, err := s.patchVolumeGroupResponseBody(volumeGroupID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchVolumeGroupResponseBody(volumeGroupID string, req PatchVolumeGroupRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if volumeGroupID == "" {
-		return body, fmt.Errorf("invalid volume group id")
+		return TaskReference{}, fmt.Errorf("invalid volume group id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/volume-groups/%s", volumeGroupID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeGroupNotFoundError{ID: volumeGroupID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/volume-groups/%s", volumeGroupID), &req, connection.NotFoundResponseHandler(&VolumeGroupNotFoundError{ID: volumeGroupID}))
+	return body.Data, err
 }
 
 // DeleteVolumeGroup deletes a volumeGroup
 func (s *Service) DeleteVolumeGroup(volumeGroupID string) (string, error) {
-	body, err := s.deleteVolumeGroupResponseBody(volumeGroupID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteVolumeGroupResponseBody(volumeGroupID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if volumeGroupID == "" {
-		return body, fmt.Errorf("invalid volume group id")
+		return "", fmt.Errorf("invalid volume group id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/volume-groups/%s", volumeGroupID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeGroupNotFoundError{ID: volumeGroupID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/volume-groups/%s", volumeGroupID), nil, connection.NotFoundResponseHandler(&VolumeGroupNotFoundError{ID: volumeGroupID}))
+	return body.Data.TaskID, err
 }
 
 // GetVolumeGroupVolumes retrieves a list of VolumeGroup volumes
@@ -139,30 +59,11 @@ func (s *Service) GetVolumeGroupVolumes(volumeGroupID string, parameters connect
 
 // GetVolumeGroupVolumesPaginated retrieves a paginated list of VolumeGroup volumes
 func (s *Service) GetVolumeGroupVolumesPaginated(volumeGroupID string, parameters connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-	body, err := s.getVolumeGroupVolumesPaginatedResponseBody(volumeGroupID, parameters)
-
+	if volumeGroupID == "" {
+		return nil, fmt.Errorf("invalid volume group id")
+	}
+	body, err := connection.Get[[]Volume](s.connection, fmt.Sprintf("/ecloud/v2/volume-groups/%s/volumes", volumeGroupID), parameters, connection.NotFoundResponseHandler(&VolumeGroupNotFoundError{ID: volumeGroupID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
 		return s.GetVolumeGroupVolumesPaginated(volumeGroupID, p)
 	}), err
-}
-
-func (s *Service) getVolumeGroupVolumesPaginatedResponseBody(volumeGroupID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Volume], error) {
-	body := &connection.APIResponseBodyData[[]Volume]{}
-
-	if volumeGroupID == "" {
-		return body, fmt.Errorf("invalid volume group id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/volume-groups/%s/volumes", volumeGroupID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeGroupNotFoundError{ID: volumeGroupID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_vpc.go
+++ b/pkg/service/ecloud/service_vpc.go
@@ -13,149 +13,47 @@ func (s *Service) GetVPCs(parameters connection.APIRequestParameters) ([]VPC, er
 
 // GetVPCsPaginated retrieves a paginated list of vpcs
 func (s *Service) GetVPCsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VPC], error) {
-	body, err := s.getVPCsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VPC](s.connection, "/ecloud/v2/vpcs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVPCsPaginated), err
-}
-
-func (s *Service) getVPCsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VPC], error) {
-	body := &connection.APIResponseBodyData[[]VPC]{}
-
-	response, err := s.connection.Get("/ecloud/v2/vpcs", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVPC retrieves a single vpc by id
 func (s *Service) GetVPC(vpcID string) (VPC, error) {
-	body, err := s.getVPCResponseBody(vpcID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVPCResponseBody(vpcID string) (*connection.APIResponseBodyData[VPC], error) {
-	body := &connection.APIResponseBodyData[VPC]{}
-
 	if vpcID == "" {
-		return body, fmt.Errorf("invalid vpc id")
+		return VPC{}, fmt.Errorf("invalid vpc id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpcs/%s", vpcID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPCNotFoundError{ID: vpcID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VPC](s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s", vpcID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
+	return body.Data, err
 }
 
 // CreateVPC creates a new VPC
 func (s *Service) CreateVPC(req CreateVPCRequest) (string, error) {
-	body, err := s.createVPCResponseBody(req)
-
+	body, err := connection.Post[VPC](s.connection, "/ecloud/v2/vpcs", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createVPCResponseBody(req CreateVPCRequest) (*connection.APIResponseBodyData[VPC], error) {
-	body := &connection.APIResponseBodyData[VPC]{}
-
-	response, err := s.connection.Post("/ecloud/v2/vpcs", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVPC patches a VPC
 func (s *Service) PatchVPC(vpcID string, req PatchVPCRequest) error {
-	_, err := s.patchVPCResponseBody(vpcID, req)
-
-	return err
-}
-
-func (s *Service) patchVPCResponseBody(vpcID string, req PatchVPCRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vpcID == "" {
-		return body, fmt.Errorf("invalid vpc id")
+		return fmt.Errorf("invalid vpc id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/vpcs/%s", vpcID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPCNotFoundError{ID: vpcID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s", vpcID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
 }
 
 // DeleteVPC deletes a VPC
 func (s *Service) DeleteVPC(vpcID string) error {
-	_, err := s.deleteVPCResponseBody(vpcID)
-
-	return err
-}
-
-func (s *Service) deleteVPCResponseBody(vpcID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vpcID == "" {
-		return body, fmt.Errorf("invalid vpc id")
+		return fmt.Errorf("invalid vpc id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/vpcs/%s", vpcID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPCNotFoundError{ID: vpcID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s", vpcID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
 }
 
 // DeployVPCDefaults deploys default resources for specified VPC
 func (s *Service) DeployVPCDefaults(vpcID string) error {
-	_, err := s.deployVPCDefaultsResponseBody(vpcID)
-
-	return err
-}
-
-func (s *Service) deployVPCDefaultsResponseBody(vpcID string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if vpcID == "" {
-		return body, fmt.Errorf("invalid vpc id")
+		return fmt.Errorf("invalid vpc id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/ecloud/v2/vpcs/%s/deploy-defaults", vpcID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPCNotFoundError{ID: vpcID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s/deploy-defaults", vpcID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
 }
 
 // GetVPCVolumes retrieves a list of firewall rule volumes
@@ -167,32 +65,13 @@ func (s *Service) GetVPCVolumes(vpcID string, parameters connection.APIRequestPa
 
 // GetVPCVolumesPaginated retrieves a paginated list of firewall rule volumes
 func (s *Service) GetVPCVolumesPaginated(vpcID string, parameters connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-	body, err := s.getVPCVolumesPaginatedResponseBody(vpcID, parameters)
-
+	if vpcID == "" {
+		return nil, fmt.Errorf("invalid vpc id")
+	}
+	body, err := connection.Get[[]Volume](s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s/volumes", vpcID), parameters, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
 		return s.GetVPCVolumesPaginated(vpcID, p)
 	}), err
-}
-
-func (s *Service) getVPCVolumesPaginatedResponseBody(vpcID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Volume], error) {
-	body := &connection.APIResponseBodyData[[]Volume]{}
-
-	if vpcID == "" {
-		return body, fmt.Errorf("invalid vpc id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpcs/%s/volumes", vpcID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPCNotFoundError{ID: vpcID}
-		}
-
-		return nil
-	})
 }
 
 // GetVPCInstances retrieves a list of firewall rule instances
@@ -204,32 +83,13 @@ func (s *Service) GetVPCInstances(vpcID string, parameters connection.APIRequest
 
 // GetVPCInstancesPaginated retrieves a paginated list of firewall rule instances
 func (s *Service) GetVPCInstancesPaginated(vpcID string, parameters connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
-	body, err := s.getVPCInstancesPaginatedResponseBody(vpcID, parameters)
-
+	if vpcID == "" {
+		return nil, fmt.Errorf("invalid vpc id")
+	}
+	body, err := connection.Get[[]Instance](s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s/instances", vpcID), parameters, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
 		return s.GetVPCInstancesPaginated(vpcID, p)
 	}), err
-}
-
-func (s *Service) getVPCInstancesPaginatedResponseBody(vpcID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Instance], error) {
-	body := &connection.APIResponseBodyData[[]Instance]{}
-
-	if vpcID == "" {
-		return body, fmt.Errorf("invalid vpc id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpcs/%s/instances", vpcID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPCNotFoundError{ID: vpcID}
-		}
-
-		return nil
-	})
 }
 
 // GetVPCTasks retrieves a list of VPC tasks
@@ -241,30 +101,11 @@ func (s *Service) GetVPCTasks(vpcID string, parameters connection.APIRequestPara
 
 // GetVPCTasksPaginated retrieves a paginated list of VPC tasks
 func (s *Service) GetVPCTasksPaginated(vpcID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getVPCTasksPaginatedResponseBody(vpcID, parameters)
-
+	if vpcID == "" {
+		return nil, fmt.Errorf("invalid vpc id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s/tasks", vpcID), parameters, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetVPCTasksPaginated(vpcID, p)
 	}), err
-}
-
-func (s *Service) getVPCTasksPaginatedResponseBody(vpcID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if vpcID == "" {
-		return body, fmt.Errorf("invalid vpc id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpcs/%s/tasks", vpcID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPCNotFoundError{ID: vpcID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_vpnendpoint.go
+++ b/pkg/service/ecloud/service_vpnendpoint.go
@@ -13,121 +13,41 @@ func (s *Service) GetVPNEndpoints(parameters connection.APIRequestParameters) ([
 
 // GetVPNEndpointsPaginated retrieves a paginated list of VPN endpoints
 func (s *Service) GetVPNEndpointsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VPNEndpoint], error) {
-	body, err := s.getVPNEndpointsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VPNEndpoint](s.connection, "/ecloud/v2/vpn-endpoints", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVPNEndpointsPaginated), err
-}
-
-func (s *Service) getVPNEndpointsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VPNEndpoint], error) {
-	body := &connection.APIResponseBodyData[[]VPNEndpoint]{}
-
-	response, err := s.connection.Get("/ecloud/v2/vpn-endpoints", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVPNEndpoint retrieves a single VPN endpoint by id
 func (s *Service) GetVPNEndpoint(endpointID string) (VPNEndpoint, error) {
-	body, err := s.getVPNEndpointResponseBody(endpointID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVPNEndpointResponseBody(endpointID string) (*connection.APIResponseBodyData[VPNEndpoint], error) {
-	body := &connection.APIResponseBodyData[VPNEndpoint]{}
-
 	if endpointID == "" {
-		return body, fmt.Errorf("invalid vpn endpoint id")
+		return VPNEndpoint{}, fmt.Errorf("invalid vpn endpoint id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s", endpointID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNEndpointNotFoundError{ID: endpointID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VPNEndpoint](s.connection, fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s", endpointID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VPNEndpointNotFoundError{ID: endpointID}))
+	return body.Data, err
 }
 
 // CreateVPNEndpoint creates a new VPN endpoint
 func (s *Service) CreateVPNEndpoint(req CreateVPNEndpointRequest) (TaskReference, error) {
-	body, err := s.createVPNEndpointResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/vpn-endpoints", &req)
 	return body.Data, err
-}
-
-func (s *Service) createVPNEndpointResponseBody(req CreateVPNEndpointRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/vpn-endpoints", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVPNEndpoint patches a VPN endpoint
 func (s *Service) PatchVPNEndpoint(endpointID string, req PatchVPNEndpointRequest) (TaskReference, error) {
-	body, err := s.patchVPNEndpointResponseBody(endpointID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchVPNEndpointResponseBody(endpointID string, req PatchVPNEndpointRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if endpointID == "" {
-		return body, fmt.Errorf("invalid endpoint id")
+		return TaskReference{}, fmt.Errorf("invalid endpoint id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s", endpointID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNEndpointNotFoundError{ID: endpointID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s", endpointID), &req, connection.NotFoundResponseHandler(&VPNEndpointNotFoundError{ID: endpointID}))
+	return body.Data, err
 }
 
 // DeleteVPNEndpoint deletes a VPN endpoint
 func (s *Service) DeleteVPNEndpoint(endpointID string) (string, error) {
-	body, err := s.deleteVPNEndpointResponseBody(endpointID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteVPNEndpointResponseBody(endpointID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if endpointID == "" {
-		return body, fmt.Errorf("invalid endpoint id")
+		return "", fmt.Errorf("invalid endpoint id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s", endpointID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNEndpointNotFoundError{ID: endpointID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s", endpointID), nil, connection.NotFoundResponseHandler(&VPNEndpointNotFoundError{ID: endpointID}))
+	return body.Data.TaskID, err
 }
 
 // GetVPNEndpointTasks retrieves a list of VPN endpoint tasks
@@ -139,30 +59,11 @@ func (s *Service) GetVPNEndpointTasks(endpointID string, parameters connection.A
 
 // GetVPNEndpointTasksPaginated retrieves a paginated list of VPN endpoint tasks
 func (s *Service) GetVPNEndpointTasksPaginated(endpointID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getVPNEndpointTasksPaginatedResponseBody(endpointID, parameters)
-
+	if endpointID == "" {
+		return nil, fmt.Errorf("invalid vpn endpoint id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s/tasks", endpointID), parameters, connection.NotFoundResponseHandler(&VPNEndpointNotFoundError{ID: endpointID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetVPNEndpointTasksPaginated(endpointID, p)
 	}), err
-}
-
-func (s *Service) getVPNEndpointTasksPaginatedResponseBody(endpointID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if endpointID == "" {
-		return body, fmt.Errorf("invalid vpn endpoint id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s/tasks", endpointID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNEndpointNotFoundError{ID: endpointID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_vpngateway.go
+++ b/pkg/service/ecloud/service_vpngateway.go
@@ -13,121 +13,41 @@ func (s *Service) GetVPNGateways(parameters connection.APIRequestParameters) ([]
 
 // GetVPNGatewaysPaginated retrieves a paginated list of VPN gateways
 func (s *Service) GetVPNGatewaysPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VPNGateway], error) {
-	body, err := s.getVPNGatewaysPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VPNGateway](s.connection, "/ecloud/v2/vpn-gateways", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVPNGatewaysPaginated), err
-}
-
-func (s *Service) getVPNGatewaysPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VPNGateway], error) {
-	body := &connection.APIResponseBodyData[[]VPNGateway]{}
-
-	response, err := s.connection.Get("/ecloud/v2/vpn-gateways", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVPNGateway retrieves a single VPN gateway by ID
 func (s *Service) GetVPNGateway(gatewayID string) (VPNGateway, error) {
-	body, err := s.getVPNGatewayResponseBody(gatewayID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVPNGatewayResponseBody(gatewayID string) (*connection.APIResponseBodyData[VPNGateway], error) {
-	body := &connection.APIResponseBodyData[VPNGateway]{}
-
 	if gatewayID == "" {
-		return body, fmt.Errorf("invalid vpn gateway id")
+		return VPNGateway{}, fmt.Errorf("invalid vpn gateway id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-gateways/%s", gatewayID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNGatewayNotFoundError{ID: gatewayID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VPNGateway](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateways/%s", gatewayID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VPNGatewayNotFoundError{ID: gatewayID}))
+	return body.Data, err
 }
 
 // CreateVPNGateway creates a new VPN gateway
 func (s *Service) CreateVPNGateway(req CreateVPNGatewayRequest) (TaskReference, error) {
-	body, err := s.createVPNGatewayResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/vpn-gateways", &req)
 	return body.Data, err
-}
-
-func (s *Service) createVPNGatewayResponseBody(req CreateVPNGatewayRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/vpn-gateways", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVPNGateway patches a VPN gateway
 func (s *Service) PatchVPNGateway(gatewayID string, req PatchVPNGatewayRequest) (TaskReference, error) {
-	body, err := s.patchVPNGatewayResponseBody(gatewayID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchVPNGatewayResponseBody(gatewayID string, req PatchVPNGatewayRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if gatewayID == "" {
-		return body, fmt.Errorf("invalid gateway id")
+		return TaskReference{}, fmt.Errorf("invalid gateway id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/vpn-gateways/%s", gatewayID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNGatewayNotFoundError{ID: gatewayID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateways/%s", gatewayID), &req, connection.NotFoundResponseHandler(&VPNGatewayNotFoundError{ID: gatewayID}))
+	return body.Data, err
 }
 
 // DeleteVPNGateway deletes a VPN gateway
 func (s *Service) DeleteVPNGateway(gatewayID string) (string, error) {
-	body, err := s.deleteVPNGatewayResponseBody(gatewayID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteVPNGatewayResponseBody(gatewayID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if gatewayID == "" {
-		return body, fmt.Errorf("invalid gateway id")
+		return "", fmt.Errorf("invalid gateway id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/vpn-gateways/%s", gatewayID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNGatewayNotFoundError{ID: gatewayID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateways/%s", gatewayID), nil, connection.NotFoundResponseHandler(&VPNGatewayNotFoundError{ID: gatewayID}))
+	return body.Data.TaskID, err
 }
 
 // GetVPNGatewayTasks retrieves a list of VPN gateway tasks
@@ -139,30 +59,11 @@ func (s *Service) GetVPNGatewayTasks(gatewayID string, parameters connection.API
 
 // GetVPNGatewayTasksPaginated retrieves a paginated list of VPN gateway tasks
 func (s *Service) GetVPNGatewayTasksPaginated(gatewayID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getVPNGatewayTasksPaginatedResponseBody(gatewayID, parameters)
-
+	if gatewayID == "" {
+		return nil, fmt.Errorf("invalid vpn gateway id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateways/%s/tasks", gatewayID), parameters, connection.NotFoundResponseHandler(&VPNGatewayNotFoundError{ID: gatewayID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetVPNGatewayTasksPaginated(gatewayID, p)
 	}), err
-}
-
-func (s *Service) getVPNGatewayTasksPaginatedResponseBody(gatewayID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if gatewayID == "" {
-		return body, fmt.Errorf("invalid vpn gateway id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-gateways/%s/tasks", gatewayID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNGatewayNotFoundError{ID: gatewayID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_vpngatewayspecs.go
+++ b/pkg/service/ecloud/service_vpngatewayspecs.go
@@ -13,47 +13,17 @@ func (s *Service) GetVPNGatewaySpecifications(parameters connection.APIRequestPa
 
 // GetVPNGatewaySpecificationsPaginated retrieves a paginated list of VPN gateway specifications
 func (s *Service) GetVPNGatewaySpecificationsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VPNGatewaySpecification], error) {
-	body, err := s.getVPNGatewaySpecificationsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VPNGatewaySpecification](s.connection, "/ecloud/v2/vpn-gateway-specifications", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVPNGatewaySpecificationsPaginated), err
-}
-
-func (s *Service) getVPNGatewaySpecificationsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VPNGatewaySpecification], error) {
-	body := &connection.APIResponseBodyData[[]VPNGatewaySpecification]{}
-
-	response, err := s.connection.Get("/ecloud/v2/vpn-gateway-specifications", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVPNGatewaySpecification retrieves a single VPN gateway specification by ID
 func (s *Service) GetVPNGatewaySpecification(specificationID string) (VPNGatewaySpecification, error) {
-	body, err := s.getVPNGatewaySpecificationResponseBody(specificationID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVPNGatewaySpecificationResponseBody(specificationID string) (*connection.APIResponseBodyData[VPNGatewaySpecification], error) {
-	body := &connection.APIResponseBodyData[VPNGatewaySpecification]{}
-
 	if specificationID == "" {
-		return body, fmt.Errorf("invalid vpn gateway specification id")
+		return VPNGatewaySpecification{}, fmt.Errorf("invalid vpn gateway specification id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-gateway-specifications/%s", specificationID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNGatewaySpecificationNotFoundError{ID: specificationID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VPNGatewaySpecification](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateway-specifications/%s", specificationID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VPNGatewaySpecificationNotFoundError{ID: specificationID}))
+	return body.Data, err
 }
 
 // GetVPNGatewaySpecificationAvailabilityZones retrieves a list of availability zones for a vpn gateway specification
@@ -65,30 +35,11 @@ func (s *Service) GetVPNGatewaySpecificationAvailabilityZones(specificationID st
 
 // GetVPNGatewaySpecificationAvailabilityZonesPaginated retrieves a paginated list of availability zones for a vpn gateway specification
 func (s *Service) GetVPNGatewaySpecificationAvailabilityZonesPaginated(specificationID string, parameters connection.APIRequestParameters) (*connection.Paginated[AvailabilityZone], error) {
-	body, err := s.getVPNGatewaySpecificationAvailabilityZonesPaginatedResponseBody(specificationID, parameters)
-
+	if specificationID == "" {
+		return nil, fmt.Errorf("invalid vpn gateway specification id")
+	}
+	body, err := connection.Get[[]AvailabilityZone](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateway-specifications/%s/availability-zones", specificationID), parameters, connection.NotFoundResponseHandler(&VPNGatewaySpecificationNotFoundError{ID: specificationID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[AvailabilityZone], error) {
 		return s.GetVPNGatewaySpecificationAvailabilityZonesPaginated(specificationID, p)
 	}), err
-}
-
-func (s *Service) getVPNGatewaySpecificationAvailabilityZonesPaginatedResponseBody(specificationID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]AvailabilityZone], error) {
-	body := &connection.APIResponseBodyData[[]AvailabilityZone]{}
-
-	if specificationID == "" {
-		return body, fmt.Errorf("invalid vpn gateway specification id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-gateway-specifications/%s/availability-zones", specificationID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNGatewaySpecificationNotFoundError{ID: specificationID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_vpngatewayusers.go
+++ b/pkg/service/ecloud/service_vpngatewayusers.go
@@ -13,119 +13,39 @@ func (s *Service) GetVPNGatewayUsers(parameters connection.APIRequestParameters)
 
 // GetVPNGatewayUsersPaginated retrieves a paginated list of VPN gateway users
 func (s *Service) GetVPNGatewayUsersPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VPNGatewayUser], error) {
-	body, err := s.getVPNGatewayUsersPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VPNGatewayUser](s.connection, "/ecloud/v2/vpn-gateway-users", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVPNGatewayUsersPaginated), err
-}
-
-func (s *Service) getVPNGatewayUsersPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VPNGatewayUser], error) {
-	body := &connection.APIResponseBodyData[[]VPNGatewayUser]{}
-
-	response, err := s.connection.Get("/ecloud/v2/vpn-gateway-users", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVPNGatewayUser retrieves a single VPN gateway user by ID
 func (s *Service) GetVPNGatewayUser(userID string) (VPNGatewayUser, error) {
-	body, err := s.getVPNGatewayUserResponseBody(userID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVPNGatewayUserResponseBody(userID string) (*connection.APIResponseBodyData[VPNGatewayUser], error) {
-	body := &connection.APIResponseBodyData[VPNGatewayUser]{}
-
 	if userID == "" {
-		return body, fmt.Errorf("invalid vpn gateway user id")
+		return VPNGatewayUser{}, fmt.Errorf("invalid vpn gateway user id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-gateway-users/%s", userID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNGatewayUserNotFoundError{ID: userID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VPNGatewayUser](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateway-users/%s", userID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VPNGatewayUserNotFoundError{ID: userID}))
+	return body.Data, err
 }
 
 // CreateVPNGatewayUser creates a new VPN gateway user
 func (s *Service) CreateVPNGatewayUser(req CreateVPNGatewayUserRequest) (TaskReference, error) {
-	body, err := s.createVPNGatewayUserResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/vpn-gateway-users", &req)
 	return body.Data, err
-}
-
-func (s *Service) createVPNGatewayUserResponseBody(req CreateVPNGatewayUserRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/vpn-gateway-users", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVPNGatewayUser patches a VPN gateway user
 func (s *Service) PatchVPNGatewayUser(userID string, req PatchVPNGatewayUserRequest) (TaskReference, error) {
-	body, err := s.patchVPNGatewayUserResponseBody(userID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchVPNGatewayUserResponseBody(userID string, req PatchVPNGatewayUserRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if userID == "" {
-		return body, fmt.Errorf("invalid user id")
+		return TaskReference{}, fmt.Errorf("invalid user id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/vpn-gateway-users/%s", userID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNGatewayUserNotFoundError{ID: userID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateway-users/%s", userID), &req, connection.NotFoundResponseHandler(&VPNGatewayUserNotFoundError{ID: userID}))
+	return body.Data, err
 }
 
 // DeleteVPNGatewayUser deletes a VPN gateway user
 func (s *Service) DeleteVPNGatewayUser(userID string) (string, error) {
-	body, err := s.deleteVPNGatewayUserResponseBody(userID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteVPNGatewayUserResponseBody(userID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if userID == "" {
-		return body, fmt.Errorf("invalid user id")
+		return "", fmt.Errorf("invalid user id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/vpn-gateway-users/%s", userID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNGatewayUserNotFoundError{ID: userID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateway-users/%s", userID), nil, connection.NotFoundResponseHandler(&VPNGatewayUserNotFoundError{ID: userID}))
+	return body.Data.TaskID, err
 }

--- a/pkg/service/ecloud/service_vpnprofilegroup.go
+++ b/pkg/service/ecloud/service_vpnprofilegroup.go
@@ -13,45 +13,15 @@ func (s *Service) GetVPNProfileGroups(parameters connection.APIRequestParameters
 
 // GetVPNProfileGroupsPaginated retrieves a paginated list of VPN profile groups
 func (s *Service) GetVPNProfileGroupsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VPNProfileGroup], error) {
-	body, err := s.getVPNProfileGroupsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VPNProfileGroup](s.connection, "/ecloud/v2/vpn-profile-groups", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVPNProfileGroupsPaginated), err
-}
-
-func (s *Service) getVPNProfileGroupsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VPNProfileGroup], error) {
-	body := &connection.APIResponseBodyData[[]VPNProfileGroup]{}
-
-	response, err := s.connection.Get("/ecloud/v2/vpn-profile-groups", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVPNProfileGroup retrieves a single VPN profile group by id
 func (s *Service) GetVPNProfileGroup(profileGroupID string) (VPNProfileGroup, error) {
-	body, err := s.getVPNProfileGroupResponseBody(profileGroupID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVPNProfileGroupResponseBody(profileGroupID string) (*connection.APIResponseBodyData[VPNProfileGroup], error) {
-	body := &connection.APIResponseBodyData[VPNProfileGroup]{}
-
 	if profileGroupID == "" {
-		return body, fmt.Errorf("invalid vpn profile group id")
+		return VPNProfileGroup{}, fmt.Errorf("invalid vpn profile group id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-profile-groups/%s", profileGroupID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNProfileGroupNotFoundError{ID: profileGroupID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VPNProfileGroup](s.connection, fmt.Sprintf("/ecloud/v2/vpn-profile-groups/%s", profileGroupID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VPNProfileGroupNotFoundError{ID: profileGroupID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloud/service_vpnservice.go
+++ b/pkg/service/ecloud/service_vpnservice.go
@@ -13,121 +13,41 @@ func (s *Service) GetVPNServices(parameters connection.APIRequestParameters) ([]
 
 // GetVPNServicesPaginated retrieves a paginated list of VPN services
 func (s *Service) GetVPNServicesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VPNService], error) {
-	body, err := s.getVPNServicesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VPNService](s.connection, "/ecloud/v2/vpn-services", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVPNServicesPaginated), err
-}
-
-func (s *Service) getVPNServicesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VPNService], error) {
-	body := &connection.APIResponseBodyData[[]VPNService]{}
-
-	response, err := s.connection.Get("/ecloud/v2/vpn-services", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVPNService retrieves a single VPN service by id
 func (s *Service) GetVPNService(serviceID string) (VPNService, error) {
-	body, err := s.getVPNServiceResponseBody(serviceID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVPNServiceResponseBody(serviceID string) (*connection.APIResponseBodyData[VPNService], error) {
-	body := &connection.APIResponseBodyData[VPNService]{}
-
 	if serviceID == "" {
-		return body, fmt.Errorf("invalid vpn service id")
+		return VPNService{}, fmt.Errorf("invalid vpn service id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-services/%s", serviceID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNServiceNotFoundError{ID: serviceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VPNService](s.connection, fmt.Sprintf("/ecloud/v2/vpn-services/%s", serviceID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VPNServiceNotFoundError{ID: serviceID}))
+	return body.Data, err
 }
 
 // CreateVPNService creates a new VPN service
 func (s *Service) CreateVPNService(req CreateVPNServiceRequest) (TaskReference, error) {
-	body, err := s.createVPNServiceResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/vpn-services", &req)
 	return body.Data, err
-}
-
-func (s *Service) createVPNServiceResponseBody(req CreateVPNServiceRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/vpn-services", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVPNService patches a VPN service
 func (s *Service) PatchVPNService(serviceID string, req PatchVPNServiceRequest) (TaskReference, error) {
-	body, err := s.patchVPNServiceResponseBody(serviceID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchVPNServiceResponseBody(serviceID string, req PatchVPNServiceRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if serviceID == "" {
-		return body, fmt.Errorf("invalid service id")
+		return TaskReference{}, fmt.Errorf("invalid service id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/vpn-services/%s", serviceID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNServiceNotFoundError{ID: serviceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-services/%s", serviceID), &req, connection.NotFoundResponseHandler(&VPNServiceNotFoundError{ID: serviceID}))
+	return body.Data, err
 }
 
 // DeleteVPNService deletes a VPN service
 func (s *Service) DeleteVPNService(serviceID string) (string, error) {
-	body, err := s.deleteVPNServiceResponseBody(serviceID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteVPNServiceResponseBody(serviceID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if serviceID == "" {
-		return body, fmt.Errorf("invalid service id")
+		return "", fmt.Errorf("invalid service id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/vpn-services/%s", serviceID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNServiceNotFoundError{ID: serviceID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-services/%s", serviceID), nil, connection.NotFoundResponseHandler(&VPNServiceNotFoundError{ID: serviceID}))
+	return body.Data.TaskID, err
 }
 
 // GetVPNServiceTasks retrieves a list of VPN service tasks
@@ -139,30 +59,11 @@ func (s *Service) GetVPNServiceTasks(serviceID string, parameters connection.API
 
 // GetVPNServiceTasksPaginated retrieves a paginated list of VPN service tasks
 func (s *Service) GetVPNServiceTasksPaginated(serviceID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getVPNServiceTasksPaginatedResponseBody(serviceID, parameters)
-
+	if serviceID == "" {
+		return nil, fmt.Errorf("invalid vpn service id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpn-services/%s/tasks", serviceID), parameters, connection.NotFoundResponseHandler(&VPNServiceNotFoundError{ID: serviceID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetVPNServiceTasksPaginated(serviceID, p)
 	}), err
-}
-
-func (s *Service) getVPNServiceTasksPaginatedResponseBody(serviceID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if serviceID == "" {
-		return body, fmt.Errorf("invalid vpn service id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-services/%s/tasks", serviceID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNServiceNotFoundError{ID: serviceID}
-		}
-
-		return nil
-	})
 }

--- a/pkg/service/ecloud/service_vpnsession.go
+++ b/pkg/service/ecloud/service_vpnsession.go
@@ -13,121 +13,41 @@ func (s *Service) GetVPNSessions(parameters connection.APIRequestParameters) ([]
 
 // GetVPNSessionsPaginated retrieves a paginated list of VPN sessions
 func (s *Service) GetVPNSessionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VPNSession], error) {
-	body, err := s.getVPNSessionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VPNSession](s.connection, "/ecloud/v2/vpn-sessions", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVPNSessionsPaginated), err
-}
-
-func (s *Service) getVPNSessionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VPNSession], error) {
-	body := &connection.APIResponseBodyData[[]VPNSession]{}
-
-	response, err := s.connection.Get("/ecloud/v2/vpn-sessions", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVPNSession retrieves a single VPN session by id
 func (s *Service) GetVPNSession(sessionID string) (VPNSession, error) {
-	body, err := s.getVPNSessionResponseBody(sessionID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVPNSessionResponseBody(sessionID string) (*connection.APIResponseBodyData[VPNSession], error) {
-	body := &connection.APIResponseBodyData[VPNSession]{}
-
 	if sessionID == "" {
-		return body, fmt.Errorf("invalid vpn session id")
+		return VPNSession{}, fmt.Errorf("invalid vpn session id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-sessions/%s", sessionID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNSessionNotFoundError{ID: sessionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VPNSession](s.connection, fmt.Sprintf("/ecloud/v2/vpn-sessions/%s", sessionID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VPNSessionNotFoundError{ID: sessionID}))
+	return body.Data, err
 }
 
 // CreateVPNSession creates a new VPN session
 func (s *Service) CreateVPNSession(req CreateVPNSessionRequest) (TaskReference, error) {
-	body, err := s.createVPNSessionResponseBody(req)
-
+	body, err := connection.Post[TaskReference](s.connection, "/ecloud/v2/vpn-sessions", &req)
 	return body.Data, err
-}
-
-func (s *Service) createVPNSessionResponseBody(req CreateVPNSessionRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
-	response, err := s.connection.Post("/ecloud/v2/vpn-sessions", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchVPNSession patches a VPN session
 func (s *Service) PatchVPNSession(sessionID string, req PatchVPNSessionRequest) (TaskReference, error) {
-	body, err := s.patchVPNSessionResponseBody(sessionID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) patchVPNSessionResponseBody(sessionID string, req PatchVPNSessionRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if sessionID == "" {
-		return body, fmt.Errorf("invalid vpn session id")
+		return TaskReference{}, fmt.Errorf("invalid vpn session id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/ecloud/v2/vpn-sessions/%s", sessionID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNSessionNotFoundError{ID: sessionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-sessions/%s", sessionID), &req, connection.NotFoundResponseHandler(&VPNSessionNotFoundError{ID: sessionID}))
+	return body.Data, err
 }
 
 // DeleteVPNSession deletes a VPN session
 func (s *Service) DeleteVPNSession(sessionID string) (string, error) {
-	body, err := s.deleteVPNSessionResponseBody(sessionID)
-
-	return body.Data.TaskID, err
-}
-
-func (s *Service) deleteVPNSessionResponseBody(sessionID string) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if sessionID == "" {
-		return body, fmt.Errorf("invalid vpn session id")
+		return "", fmt.Errorf("invalid vpn session id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/ecloud/v2/vpn-sessions/%s", sessionID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNSessionNotFoundError{ID: sessionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Delete[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-sessions/%s", sessionID), nil, connection.NotFoundResponseHandler(&VPNSessionNotFoundError{ID: sessionID}))
+	return body.Data.TaskID, err
 }
 
 // GetVPNSessionTasks retrieves a list of VPN session tasks
@@ -139,86 +59,29 @@ func (s *Service) GetVPNSessionTasks(sessionID string, parameters connection.API
 
 // GetVPNSessionTasksPaginated retrieves a paginated list of VPN session tasks
 func (s *Service) GetVPNSessionTasksPaginated(sessionID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	body, err := s.getVPNSessionTasksPaginatedResponseBody(sessionID, parameters)
-
+	if sessionID == "" {
+		return nil, fmt.Errorf("invalid vpn session id")
+	}
+	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpn-sessions/%s/tasks", sessionID), parameters, connection.NotFoundResponseHandler(&VPNSessionNotFoundError{ID: sessionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
 		return s.GetVPNSessionTasksPaginated(sessionID, p)
 	}), err
 }
 
-func (s *Service) getVPNSessionTasksPaginatedResponseBody(sessionID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Task], error) {
-	body := &connection.APIResponseBodyData[[]Task]{}
-
-	if sessionID == "" {
-		return body, fmt.Errorf("invalid vpn session id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-sessions/%s/tasks", sessionID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNSessionNotFoundError{ID: sessionID}
-		}
-
-		return nil
-	})
-}
-
-// GetVPNSession retrieves a single VPN session by id
+// GetVPNSessionPreSharedKey retrieves a single VPN session by id
 func (s *Service) GetVPNSessionPreSharedKey(sessionID string) (VPNSessionPreSharedKey, error) {
-	body, err := s.getVPNSessionPreSharedKeyResponseBody(sessionID)
-
+	if sessionID == "" {
+		return VPNSessionPreSharedKey{}, fmt.Errorf("invalid vpn session id")
+	}
+	body, err := connection.Get[VPNSessionPreSharedKey](s.connection, fmt.Sprintf("/ecloud/v2/vpn-sessions/%s/pre-shared-key", sessionID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VPNSessionNotFoundError{ID: sessionID}))
 	return body.Data, err
 }
 
-func (s *Service) getVPNSessionPreSharedKeyResponseBody(sessionID string) (*connection.APIResponseBodyData[VPNSessionPreSharedKey], error) {
-	body := &connection.APIResponseBodyData[VPNSessionPreSharedKey]{}
-
-	if sessionID == "" {
-		return body, fmt.Errorf("invalid vpn session id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud/v2/vpn-sessions/%s/pre-shared-key", sessionID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNSessionNotFoundError{ID: sessionID}
-		}
-
-		return nil
-	})
-}
-
-// UpdateVPNSession retrieves a single VPN session by id
+// UpdateVPNSessionPreSharedKey retrieves a single VPN session by id
 func (s *Service) UpdateVPNSessionPreSharedKey(sessionID string, req UpdateVPNSessionPreSharedKeyRequest) (TaskReference, error) {
-	body, err := s.updateVPNSessionPreSharedKeyResponseBody(sessionID, req)
-
-	return body.Data, err
-}
-
-func (s *Service) updateVPNSessionPreSharedKeyResponseBody(sessionID string, req UpdateVPNSessionPreSharedKeyRequest) (*connection.APIResponseBodyData[TaskReference], error) {
-	body := &connection.APIResponseBodyData[TaskReference]{}
-
 	if sessionID == "" {
-		return body, fmt.Errorf("invalid vpn session id")
+		return TaskReference{}, fmt.Errorf("invalid vpn session id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/ecloud/v2/vpn-sessions/%s/pre-shared-key", sessionID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VPNSessionNotFoundError{ID: sessionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Put[TaskReference](s.connection, fmt.Sprintf("/ecloud/v2/vpn-sessions/%s/pre-shared-key", sessionID), &req, connection.NotFoundResponseHandler(&VPNSessionNotFoundError{ID: sessionID}))
+	return body.Data, err
 }

--- a/pkg/service/ecloudflex/service_project.go
+++ b/pkg/service/ecloudflex/service_project.go
@@ -13,45 +13,15 @@ func (s *Service) GetProjects(parameters connection.APIRequestParameters) ([]Pro
 
 // GetProjectsPaginated retrieves a paginated list of projects
 func (s *Service) GetProjectsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Project], error) {
-	body, err := s.getProjectsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Project](s.connection, "/ecloud-flex/v1/projects", parameters)
 	return connection.NewPaginated(body, parameters, s.GetProjectsPaginated), err
-}
-
-func (s *Service) getProjectsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Project], error) {
-	body := &connection.APIResponseBodyData[[]Project]{}
-
-	response, err := s.connection.Get("/ecloud-flex/v1/projects", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetProject retrieves a single project by id
 func (s *Service) GetProject(projectID int) (Project, error) {
-	body, err := s.getProjectResponseBody(projectID)
-
-	return body.Data, err
-}
-
-func (s *Service) getProjectResponseBody(projectID int) (*connection.APIResponseBodyData[Project], error) {
-	body := &connection.APIResponseBodyData[Project]{}
-
 	if projectID < 1 {
-		return body, fmt.Errorf("invalid project id")
+		return Project{}, fmt.Errorf("invalid project id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ecloud-flex/v1/projects/%d", projectID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ProjectNotFoundError{ID: projectID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Project](s.connection, fmt.Sprintf("/ecloud-flex/v1/projects/%d", projectID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ProjectNotFoundError{ID: projectID}))
+	return body.Data, err
 }

--- a/pkg/service/loadbalancer/service_accessip.go
+++ b/pkg/service/loadbalancer/service_accessip.go
@@ -8,84 +8,25 @@ import (
 
 // GetAccessIP retrieves a single access IP by id
 func (s *Service) GetAccessIP(accessID int) (AccessIP, error) {
-	body, err := s.getAccessIPResponseBody(accessID)
-
-	return body.Data, err
-}
-
-func (s *Service) getAccessIPResponseBody(accessID int) (*connection.APIResponseBodyData[AccessIP], error) {
-	body := &connection.APIResponseBodyData[AccessIP]{}
-
 	if accessID < 1 {
-		return body, fmt.Errorf("invalid access id")
+		return AccessIP{}, fmt.Errorf("invalid access id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/access-ips/%d", accessID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AccessIPNotFoundError{ID: accessID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[AccessIP](s.connection, fmt.Sprintf("/loadbalancers/v2/access-ips/%d", accessID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&AccessIPNotFoundError{ID: accessID}))
+	return body.Data, err
 }
 
 // PatchAccessIP patches an access IP
 func (s *Service) PatchAccessIP(accessID int, req PatchAccessIPRequest) error {
-	_, err := s.patchAccessIPResponseBody(accessID, req)
-
-	return err
-}
-
-func (s *Service) patchAccessIPResponseBody(accessID int, req PatchAccessIPRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if accessID < 1 {
-		return body, fmt.Errorf("invalid access id")
+		return fmt.Errorf("invalid access id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/loadbalancers/v2/access-ips/%d", accessID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AccessIPNotFoundError{ID: accessID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/access-ips/%d", accessID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&AccessIPNotFoundError{ID: accessID}))
 }
 
 // DeleteAccessIP deletes an access IP
 func (s *Service) DeleteAccessIP(accessID int) error {
-	_, err := s.deleteAccessIPResponseBody(accessID)
-
-	return err
-}
-
-func (s *Service) deleteAccessIPResponseBody(accessID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if accessID < 1 {
-		return body, fmt.Errorf("invalid access id")
+		return fmt.Errorf("invalid access id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/loadbalancers/v2/access-ips/%d", accessID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AccessIPNotFoundError{ID: accessID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/access-ips/%d", accessID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&AccessIPNotFoundError{ID: accessID}))
 }

--- a/pkg/service/loadbalancer/service_acl.go
+++ b/pkg/service/loadbalancer/service_acl.go
@@ -15,119 +15,37 @@ func (s *Service) GetACLs(parameters connection.APIRequestParameters) ([]ACL, er
 // GetACLsPaginated retrieves a paginated list of ACLs
 // Currently, a target_group_id or listener_id filter must be provided for this to return data
 func (s *Service) GetACLsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
-	body, err := s.getACLsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]ACL](s.connection, "/loadbalancers/v2/acls", parameters)
 	return connection.NewPaginated(body, parameters, s.GetACLsPaginated), err
-}
-
-func (s *Service) getACLsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ACL], error) {
-	body := &connection.APIResponseBodyData[[]ACL]{}
-
-	response, err := s.connection.Get("/loadbalancers/v2/acls", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetACL retrieves a single ACL by id
 func (s *Service) GetACL(aclID int) (ACL, error) {
-	body, err := s.getACLResponseBody(aclID)
-
-	return body.Data, err
-}
-
-func (s *Service) getACLResponseBody(aclID int) (*connection.APIResponseBodyData[ACL], error) {
-	body := &connection.APIResponseBodyData[ACL]{}
-
 	if aclID < 1 {
-		return body, fmt.Errorf("invalid acl id")
+		return ACL{}, fmt.Errorf("invalid acl id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/acls/%d", aclID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ACLNotFoundError{ID: aclID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[ACL](s.connection, fmt.Sprintf("/loadbalancers/v2/acls/%d", aclID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ACLNotFoundError{ID: aclID}))
+	return body.Data, err
 }
 
 // CreateACL creates an ACL
 func (s *Service) CreateACL(req CreateACLRequest) (int, error) {
-	body, err := s.createACLResponseBody(req)
-
+	body, err := connection.Post[ACL](s.connection, "/loadbalancers/v2/acls", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createACLResponseBody(req CreateACLRequest) (*connection.APIResponseBodyData[ACL], error) {
-	body := &connection.APIResponseBodyData[ACL]{}
-
-	response, err := s.connection.Post("/loadbalancers/v2/acls", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body)
 }
 
 // PatchACL patches an ACL
 func (s *Service) PatchACL(aclID int, req PatchACLRequest) error {
-	_, err := s.patchACLResponseBody(aclID, req)
-
-	return err
-}
-
-func (s *Service) patchACLResponseBody(aclID int, req PatchACLRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if aclID < 1 {
-		return body, fmt.Errorf("invalid acl id")
+		return fmt.Errorf("invalid acl id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/loadbalancers/v2/acls/%d", aclID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ACLNotFoundError{ID: aclID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/acls/%d", aclID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ACLNotFoundError{ID: aclID}))
 }
 
 // DeleteACL deletes an ACL
 func (s *Service) DeleteACL(aclID int) error {
-	_, err := s.deleteACLResponseBody(aclID)
-
-	return err
-}
-
-func (s *Service) deleteACLResponseBody(aclID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if aclID < 1 {
-		return body, fmt.Errorf("invalid acl id")
+		return fmt.Errorf("invalid acl id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/loadbalancers/v2/acls/%d", aclID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ACLNotFoundError{ID: aclID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/acls/%d", aclID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ACLNotFoundError{ID: aclID}))
 }

--- a/pkg/service/loadbalancer/service_bind.go
+++ b/pkg/service/loadbalancer/service_bind.go
@@ -11,17 +11,6 @@ func (s *Service) GetBinds(parameters connection.APIRequestParameters) ([]Bind, 
 
 // GetBindsPaginated retrieves a paginated list of binds
 func (s *Service) GetBindsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Bind], error) {
-	body, err := s.getBindsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Bind](s.connection, "/loadbalancers/v2/binds", parameters)
 	return connection.NewPaginated(body, parameters, s.GetBindsPaginated), err
-}
-
-func (s *Service) getBindsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Bind], error) {
-	body := &connection.APIResponseBodyData[[]Bind]{}
-
-	response, err := s.connection.Get("/loadbalancers/v2/binds", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/loadbalancer/service_certificate.go
+++ b/pkg/service/loadbalancer/service_certificate.go
@@ -11,10 +11,6 @@ func (s *Service) GetCertificates(parameters connection.APIRequestParameters) ([
 
 // GetCertificatesPaginated retrieves a paginated list of certificates
 func (s *Service) GetCertificatesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Certificate], error) {
-	body, err := s.getCertificatesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Certificate](s.connection, "/loadbalancers/v2/certs", parameters)
 	return connection.NewPaginated(body, parameters, s.GetCertificatesPaginated), err
-}
-
-func (s *Service) getCertificatesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Certificate], error) {
-	return connection.Get[[]Certificate](s.connection, "/loadbalancers/v2/certs", parameters)
 }

--- a/pkg/service/loadbalancer/service_cluster.go
+++ b/pkg/service/loadbalancer/service_cluster.go
@@ -14,103 +14,33 @@ func (s *Service) GetClusters(parameters connection.APIRequestParameters) ([]Clu
 
 // GetClustersPaginated retrieves a paginated list of clusters
 func (s *Service) GetClustersPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Cluster], error) {
-	body, err := s.getClustersPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Cluster](s.connection, "/loadbalancers/v2/clusters", parameters)
 	return connection.NewPaginated(body, parameters, s.GetClustersPaginated), err
-}
-
-func (s *Service) getClustersPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Cluster], error) {
-	body := &connection.APIResponseBodyData[[]Cluster]{}
-
-	response, err := s.connection.Get("/loadbalancers/v2/clusters", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetCluster retrieves a single cluster by id
 func (s *Service) GetCluster(clusterID int) (Cluster, error) {
-	body, err := s.getClusterResponseBody(clusterID)
-
-	return body.Data, err
-}
-
-func (s *Service) getClusterResponseBody(clusterID int) (*connection.APIResponseBodyData[Cluster], error) {
-	body := &connection.APIResponseBodyData[Cluster]{}
-
 	if clusterID < 1 {
-		return body, fmt.Errorf("invalid cluster id")
+		return Cluster{}, fmt.Errorf("invalid cluster id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/clusters/%d", clusterID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ClusterNotFoundError{ID: clusterID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Cluster](s.connection, fmt.Sprintf("/loadbalancers/v2/clusters/%d", clusterID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ClusterNotFoundError{ID: clusterID}))
+	return body.Data, err
 }
 
 // PatchCluster patches a Cluster
 func (s *Service) PatchCluster(clusterID int, req PatchClusterRequest) error {
-	_, err := s.patchClusterResponseBody(clusterID, req)
-
-	return err
-}
-
-func (s *Service) patchClusterResponseBody(clusterID int, req PatchClusterRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if clusterID < 1 {
-		return body, fmt.Errorf("invalid cluster id")
+		return fmt.Errorf("invalid cluster id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/loadbalancers/v2/clusters/%d", clusterID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ClusterNotFoundError{ID: clusterID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/clusters/%d", clusterID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ClusterNotFoundError{ID: clusterID}))
 }
 
 // DeployCluster deploys a Cluster
 func (s *Service) DeployCluster(clusterID int) error {
-	_, err := s.deployClusterResponseBody(clusterID)
-
-	return err
-}
-
-func (s *Service) deployClusterResponseBody(clusterID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if clusterID < 1 {
-		return body, fmt.Errorf("invalid cluster id")
+		return fmt.Errorf("invalid cluster id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/loadbalancers/v2/clusters/%d/deploy", clusterID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ClusterNotFoundError{ID: clusterID}
-		}
-
-		return nil
-	})
+	return connection.PostRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/clusters/%d/deploy", clusterID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ClusterNotFoundError{ID: clusterID}))
 }
 
 // ValidateCluster validates a cluster
@@ -145,30 +75,11 @@ type validateClusterResponseBody struct {
 	connection.APIResponseBody
 }
 
-// GetCluster retrieves a single cluster by id
+// GetClusterACLTemplates retrieves a single cluster by id
 func (s *Service) GetClusterACLTemplates(clusterID int) (ACLTemplates, error) {
-	body, err := s.getClusterACLTemplatesResponseBody(clusterID)
-
-	return body.Data, err
-}
-
-func (s *Service) getClusterACLTemplatesResponseBody(clusterID int) (*connection.APIResponseBodyData[ACLTemplates], error) {
-	body := &connection.APIResponseBodyData[ACLTemplates]{}
-
 	if clusterID < 1 {
-		return body, fmt.Errorf("invalid cluster id")
+		return ACLTemplates{}, fmt.Errorf("invalid cluster id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/clusters/%d/acl-templates", clusterID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ClusterNotFoundError{ID: clusterID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[ACLTemplates](s.connection, fmt.Sprintf("/loadbalancers/v2/clusters/%d/acl-templates", clusterID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ClusterNotFoundError{ID: clusterID}))
+	return body.Data, err
 }

--- a/pkg/service/loadbalancer/service_deployment.go
+++ b/pkg/service/loadbalancer/service_deployment.go
@@ -13,25 +13,15 @@ func (s *Service) GetDeployments(parameters connection.APIRequestParameters) ([]
 
 // GetDeploymentsPaginated retrieves a paginated list of deployments
 func (s *Service) GetDeploymentsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Deployment], error) {
-	body, err := s.getDeploymentsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Deployment](s.connection, "/loadbalancers/v2/deployments", parameters)
 	return connection.NewPaginated(body, parameters, s.GetDeploymentsPaginated), err
-}
-
-func (s *Service) getDeploymentsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Deployment], error) {
-	return connection.Get[[]Deployment](s.connection, "/loadbalancers/v2/deployments", parameters)
 }
 
 // GetDeployment retrieves a single deployment by id
 func (s *Service) GetDeployment(deploymentID int) (Deployment, error) {
-	body, err := s.getDeploymentResponseBody(deploymentID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDeploymentResponseBody(deploymentID int) (*connection.APIResponseBodyData[Deployment], error) {
 	if deploymentID < 1 {
-		return &connection.APIResponseBodyData[Deployment]{}, fmt.Errorf("invalid deployment id")
+		return Deployment{}, fmt.Errorf("invalid deployment id")
 	}
-
-	return connection.Get[Deployment](s.connection, fmt.Sprintf("/loadbalancers/v2/deployments/%d", deploymentID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DeploymentNotFoundError{ID: deploymentID}))
+	body, err := connection.Get[Deployment](s.connection, fmt.Sprintf("/loadbalancers/v2/deployments/%d", deploymentID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DeploymentNotFoundError{ID: deploymentID}))
+	return body.Data, err
 }

--- a/pkg/service/loadbalancer/service_listener.go
+++ b/pkg/service/loadbalancer/service_listener.go
@@ -13,138 +13,49 @@ func (s *Service) GetListeners(parameters connection.APIRequestParameters) ([]Li
 
 // GetListenersPaginated retrieves a paginated list of listeners
 func (s *Service) GetListenersPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Listener], error) {
-	body, err := s.getListenersPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Listener](s.connection, "/loadbalancers/v2/listeners", parameters)
 	return connection.NewPaginated(body, parameters, s.GetListenersPaginated), err
-}
-
-func (s *Service) getListenersPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Listener], error) {
-	body := &connection.APIResponseBodyData[[]Listener]{}
-
-	response, err := s.connection.Get("/loadbalancers/v2/listeners", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetListener retrieves a single listener by id
 func (s *Service) GetListener(listenerID int) (Listener, error) {
-	body, err := s.getListenerResponseBody(listenerID)
-
-	return body.Data, err
-}
-
-func (s *Service) getListenerResponseBody(listenerID int) (*connection.APIResponseBodyData[Listener], error) {
-	body := &connection.APIResponseBodyData[Listener]{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return Listener{}, fmt.Errorf("invalid listener id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/listeners/%d", listenerID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ListenerNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Listener](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d", listenerID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ListenerNotFoundError{ID: listenerID}))
+	return body.Data, err
 }
 
 // CreateListener creates a listener
 func (s *Service) CreateListener(req CreateListenerRequest) (int, error) {
-	body, err := s.createListenerResponseBody(req)
-
+	body, err := connection.Post[Listener](s.connection, "/loadbalancers/v2/listeners", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createListenerResponseBody(req CreateListenerRequest) (*connection.APIResponseBodyData[Listener], error) {
-	body := &connection.APIResponseBodyData[Listener]{}
-
-	response, err := s.connection.Post("/loadbalancers/v2/listeners", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body)
 }
 
 // PatchListener patches a listener
 func (s *Service) PatchListener(listenerID int, req PatchListenerRequest) error {
-	_, err := s.patchListenerResponseBody(listenerID, req)
-
-	return err
-}
-
-func (s *Service) patchListenerResponseBody(listenerID int, req PatchListenerRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return fmt.Errorf("invalid listener id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/loadbalancers/v2/listeners/%d", listenerID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ListenerNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d", listenerID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ListenerNotFoundError{ID: listenerID}))
 }
 
-// PatchListener patches a listener
+// DisableListenerGeoIP patches a listener
 func (s *Service) DisableListenerGeoIP(listenerID int) error {
-	_, err := s.disableListenerGeoIPResponseBody(listenerID)
-
-	return err
-}
-
-func (s *Service) disableListenerGeoIPResponseBody(listenerID int) (*connection.APIResponseBodyData[interface{}], error) {
 	if listenerID < 1 {
-		return nil, fmt.Errorf("invalid listener id")
+		return fmt.Errorf("invalid listener id")
 	}
-
 	disableGeoIPReq := struct {
 		GeoIP interface{} `json:"geoip"`
 	}{}
-
-	return connection.Patch[interface{}](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d", listenerID), &disableGeoIPReq, connection.NotFoundResponseHandler(&ListenerNotFoundError{ID: listenerID}))
+	_, err := connection.Patch[interface{}](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d", listenerID), &disableGeoIPReq, connection.NotFoundResponseHandler(&ListenerNotFoundError{ID: listenerID}))
+	return err
 }
 
 // DeleteListener deletes a listener
 func (s *Service) DeleteListener(listenerID int) error {
-	_, err := s.deleteListenerResponseBody(listenerID)
-
-	return err
-}
-
-func (s *Service) deleteListenerResponseBody(listenerID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return fmt.Errorf("invalid listener id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/loadbalancers/v2/listeners/%d", listenerID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ListenerNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d", listenerID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ListenerNotFoundError{ID: listenerID}))
 }

--- a/pkg/service/loadbalancer/service_listener_accessip.go
+++ b/pkg/service/loadbalancer/service_listener_accessip.go
@@ -15,84 +15,32 @@ func (s *Service) GetListenerAccessIPs(listenerID int, parameters connection.API
 
 // GetListenerAccessIPsPaginated retrieves a paginated list of access IPs
 func (s *Service) GetListenerAccessIPsPaginated(listenerID int, parameters connection.APIRequestParameters) (*connection.Paginated[AccessIP], error) {
-	body, err := s.getListenerAccessIPsPaginatedResponseBody(listenerID, parameters)
-
+	if listenerID < 1 {
+		return nil, fmt.Errorf("invalid listener id")
+	}
+	body, err := connection.Get[[]AccessIP](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips", listenerID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[AccessIP], error) {
 		return s.GetListenerAccessIPsPaginated(listenerID, p)
 	}), err
 }
 
-func (s *Service) getListenerAccessIPsPaginatedResponseBody(listenerID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]AccessIP], error) {
-	body := &connection.APIResponseBodyData[[]AccessIP]{}
-
-	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips", listenerID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
-}
-
 // GetListenerAccessIP retrieves a single access IP by id
 func (s *Service) GetListenerAccessIP(listenerID int, accessID int) (AccessIP, error) {
-	body, err := s.getListenerAccessIPResponseBody(listenerID, accessID)
-
-	return body.Data, err
-}
-
-func (s *Service) getListenerAccessIPResponseBody(listenerID int, accessID int) (*connection.APIResponseBodyData[AccessIP], error) {
-	body := &connection.APIResponseBodyData[AccessIP]{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return AccessIP{}, fmt.Errorf("invalid listener id")
 	}
-
 	if accessID < 1 {
-		return body, fmt.Errorf("invalid access id")
+		return AccessIP{}, fmt.Errorf("invalid access id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips/%d", listenerID, accessID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AccessIPNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[AccessIP](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips/%d", listenerID, accessID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&AccessIPNotFoundError{ID: listenerID}))
+	return body.Data, err
 }
 
 // CreateListenerAccessIP creates an access IP
 func (s *Service) CreateListenerAccessIP(listenerID int, req CreateAccessIPRequest) (int, error) {
-	body, err := s.createListenerAccessIPResponseBody(listenerID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createListenerAccessIPResponseBody(listenerID int, req CreateAccessIPRequest) (*connection.APIResponseBodyData[AccessIP], error) {
-	body := &connection.APIResponseBodyData[AccessIP]{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return 0, fmt.Errorf("invalid listener id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips", listenerID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AccessIPNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[AccessIP](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips", listenerID), &req, connection.NotFoundResponseHandler(&AccessIPNotFoundError{ID: listenerID}))
+	return body.Data.ID, err
 }

--- a/pkg/service/loadbalancer/service_listener_acl.go
+++ b/pkg/service/loadbalancer/service_listener_acl.go
@@ -15,24 +15,11 @@ func (s *Service) GetListenerACLs(listenerID int, parameters connection.APIReque
 
 // GetListenerACLsPaginated retrieves a paginated list of ACLs
 func (s *Service) GetListenerACLsPaginated(listenerID int, parameters connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
-	body, err := s.getListenerACLsPaginatedResponseBody(listenerID, parameters)
-
+	if listenerID < 1 {
+		return nil, fmt.Errorf("invalid listener id")
+	}
+	body, err := connection.Get[[]ACL](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/acls", listenerID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
 		return s.GetListenerACLsPaginated(listenerID, p)
 	}), err
-}
-
-func (s *Service) getListenerACLsPaginatedResponseBody(listenerID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ACL], error) {
-	body := &connection.APIResponseBodyData[[]ACL]{}
-
-	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/listeners/%d/acls", listenerID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/loadbalancer/service_listener_bind.go
+++ b/pkg/service/loadbalancer/service_listener_bind.go
@@ -15,148 +15,54 @@ func (s *Service) GetListenerBinds(listenerID int, parameters connection.APIRequ
 
 // GetListenerBindsPaginated retrieves a paginated list of binds
 func (s *Service) GetListenerBindsPaginated(listenerID int, parameters connection.APIRequestParameters) (*connection.Paginated[Bind], error) {
-	body, err := s.getListenerBindsPaginatedResponseBody(listenerID, parameters)
-
+	if listenerID < 1 {
+		return nil, fmt.Errorf("invalid listener id")
+	}
+	body, err := connection.Get[[]Bind](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds", listenerID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Bind], error) {
 		return s.GetListenerBindsPaginated(listenerID, p)
 	}), err
 }
 
-func (s *Service) getListenerBindsPaginatedResponseBody(listenerID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Bind], error) {
-	body := &connection.APIResponseBodyData[[]Bind]{}
-
-	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds", listenerID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
-}
-
 // GetListenerBind retrieves a single bind by id
 func (s *Service) GetListenerBind(listenerID int, bindID int) (Bind, error) {
-	body, err := s.getListenerBindResponseBody(listenerID, bindID)
-
-	return body.Data, err
-}
-
-func (s *Service) getListenerBindResponseBody(listenerID int, bindID int) (*connection.APIResponseBodyData[Bind], error) {
-	body := &connection.APIResponseBodyData[Bind]{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return Bind{}, fmt.Errorf("invalid listener id")
 	}
-
 	if bindID < 1 {
-		return body, fmt.Errorf("invalid bind id")
+		return Bind{}, fmt.Errorf("invalid bind id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds/%d", listenerID, bindID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &BindNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Bind](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds/%d", listenerID, bindID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&BindNotFoundError{ID: listenerID}))
+	return body.Data, err
 }
 
 // CreateListenerBind creates an bind
 func (s *Service) CreateListenerBind(listenerID int, req CreateBindRequest) (int, error) {
-	body, err := s.createListenerBindResponseBody(listenerID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createListenerBindResponseBody(listenerID int, req CreateBindRequest) (*connection.APIResponseBodyData[Bind], error) {
-	body := &connection.APIResponseBodyData[Bind]{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return 0, fmt.Errorf("invalid listener id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds", listenerID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &BindNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[Bind](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds", listenerID), &req, connection.NotFoundResponseHandler(&BindNotFoundError{ID: listenerID}))
+	return body.Data.ID, err
 }
 
 // PatchListenerBind patches an bind
 func (s *Service) PatchListenerBind(listenerID int, bindID int, req PatchBindRequest) error {
-	_, err := s.patchListenerBindResponseBody(listenerID, bindID, req)
-
-	return err
-}
-
-func (s *Service) patchListenerBindResponseBody(listenerID int, bindID int, req PatchBindRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return fmt.Errorf("invalid listener id")
 	}
-
 	if bindID < 1 {
-		return body, fmt.Errorf("invalid bind id")
+		return fmt.Errorf("invalid bind id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds/%d", listenerID, bindID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &BindNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds/%d", listenerID, bindID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&BindNotFoundError{ID: listenerID}))
 }
 
 // DeleteListenerBind deletes a bind
 func (s *Service) DeleteListenerBind(listenerID int, bindID int) error {
-	_, err := s.deleteListenerBindResponseBody(listenerID, bindID)
-
-	return err
-}
-
-func (s *Service) deleteListenerBindResponseBody(listenerID int, bindID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return fmt.Errorf("invalid listener id")
 	}
-
 	if bindID < 1 {
-		return body, fmt.Errorf("invalid bind id")
+		return fmt.Errorf("invalid bind id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds/%d", listenerID, bindID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &BindNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds/%d", listenerID, bindID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&BindNotFoundError{ID: listenerID}))
 }

--- a/pkg/service/loadbalancer/service_listener_certificate.go
+++ b/pkg/service/loadbalancer/service_listener_certificate.go
@@ -15,148 +15,54 @@ func (s *Service) GetListenerCertificates(listenerID int, parameters connection.
 
 // GetListenerCertificatesPaginated retrieves a paginated list of certificates
 func (s *Service) GetListenerCertificatesPaginated(listenerID int, parameters connection.APIRequestParameters) (*connection.Paginated[Certificate], error) {
-	body, err := s.getListenerCertificatesPaginatedResponseBody(listenerID, parameters)
-
+	if listenerID < 1 {
+		return nil, fmt.Errorf("invalid listener id")
+	}
+	body, err := connection.Get[[]Certificate](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs", listenerID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Certificate], error) {
 		return s.GetListenerCertificatesPaginated(listenerID, p)
 	}), err
 }
 
-func (s *Service) getListenerCertificatesPaginatedResponseBody(listenerID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Certificate], error) {
-	body := &connection.APIResponseBodyData[[]Certificate]{}
-
-	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs", listenerID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
-}
-
 // GetListenerCertificate retrieves a single certificate by id
 func (s *Service) GetListenerCertificate(listenerID int, certificateID int) (Certificate, error) {
-	body, err := s.getListenerCertificateResponseBody(listenerID, certificateID)
-
-	return body.Data, err
-}
-
-func (s *Service) getListenerCertificateResponseBody(listenerID int, certificateID int) (*connection.APIResponseBodyData[Certificate], error) {
-	body := &connection.APIResponseBodyData[Certificate]{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return Certificate{}, fmt.Errorf("invalid listener id")
 	}
-
 	if certificateID < 1 {
-		return body, fmt.Errorf("invalid certificate id")
+		return Certificate{}, fmt.Errorf("invalid certificate id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs/%d", listenerID, certificateID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CertificateNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Certificate](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs/%d", listenerID, certificateID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: listenerID}))
+	return body.Data, err
 }
 
 // CreateListenerCertificate creates an certificate
 func (s *Service) CreateListenerCertificate(listenerID int, req CreateCertificateRequest) (int, error) {
-	body, err := s.createListenerCertificateResponseBody(listenerID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createListenerCertificateResponseBody(listenerID int, req CreateCertificateRequest) (*connection.APIResponseBodyData[Certificate], error) {
-	body := &connection.APIResponseBodyData[Certificate]{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return 0, fmt.Errorf("invalid listener id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs", listenerID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CertificateNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[Certificate](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs", listenerID), &req, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: listenerID}))
+	return body.Data.ID, err
 }
 
 // PatchListenerCertificate patches an certificate
 func (s *Service) PatchListenerCertificate(listenerID int, certificateID int, req PatchCertificateRequest) error {
-	_, err := s.patchListenerCertificateResponseBody(listenerID, certificateID, req)
-
-	return err
-}
-
-func (s *Service) patchListenerCertificateResponseBody(listenerID int, certificateID int, req PatchCertificateRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return fmt.Errorf("invalid listener id")
 	}
-
 	if certificateID < 1 {
-		return body, fmt.Errorf("invalid certificate id")
+		return fmt.Errorf("invalid certificate id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs/%d", listenerID, certificateID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CertificateNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs/%d", listenerID, certificateID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: listenerID}))
 }
 
 // DeleteListenerCertificate deletes a certificate
 func (s *Service) DeleteListenerCertificate(listenerID int, certificateID int) error {
-	_, err := s.deleteListenerCertificateResponseBody(listenerID, certificateID)
-
-	return err
-}
-
-func (s *Service) deleteListenerCertificateResponseBody(listenerID int, certificateID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if listenerID < 1 {
-		return body, fmt.Errorf("invalid listener id")
+		return fmt.Errorf("invalid listener id")
 	}
-
 	if certificateID < 1 {
-		return body, fmt.Errorf("invalid certificate id")
+		return fmt.Errorf("invalid certificate id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs/%d", listenerID, certificateID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CertificateNotFoundError{ID: listenerID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs/%d", listenerID, certificateID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: listenerID}))
 }

--- a/pkg/service/loadbalancer/service_targetgroup.go
+++ b/pkg/service/loadbalancer/service_targetgroup.go
@@ -13,119 +13,37 @@ func (s *Service) GetTargetGroups(parameters connection.APIRequestParameters) ([
 
 // GetTargetGroupsPaginated retrieves a paginated list of target groups
 func (s *Service) GetTargetGroupsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[TargetGroup], error) {
-	body, err := s.getTargetGroupsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]TargetGroup](s.connection, "/loadbalancers/v2/target-groups", parameters)
 	return connection.NewPaginated(body, parameters, s.GetTargetGroupsPaginated), err
-}
-
-func (s *Service) getTargetGroupsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]TargetGroup], error) {
-	body := &connection.APIResponseBodyData[[]TargetGroup]{}
-
-	response, err := s.connection.Get("/loadbalancers/v2/target-groups", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetTargetGroup retrieves a single target group by id
 func (s *Service) GetTargetGroup(groupID int) (TargetGroup, error) {
-	body, err := s.getTargetGroupResponseBody(groupID)
-
+	if groupID < 1 {
+		return TargetGroup{}, fmt.Errorf("invalid target group id")
+	}
+	body, err := connection.Get[TargetGroup](s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d", groupID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TargetGroupNotFoundError{ID: groupID}))
 	return body.Data, err
 }
 
-func (s *Service) getTargetGroupResponseBody(groupID int) (*connection.APIResponseBodyData[TargetGroup], error) {
-	body := &connection.APIResponseBodyData[TargetGroup]{}
-
-	if groupID < 1 {
-		return body, fmt.Errorf("invalid target group id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/target-groups/%d", groupID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TargetGroupNotFoundError{ID: groupID}
-		}
-
-		return nil
-	})
-}
-
-// PatchTargetGroup patches a target group
+// CreateTargetGroup creates a target group
 func (s *Service) CreateTargetGroup(req CreateTargetGroupRequest) (int, error) {
-	body, err := s.createTargetGroupResponseBody(req)
-
+	body, err := connection.Post[TargetGroup](s.connection, "/loadbalancers/v2/target-groups", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createTargetGroupResponseBody(req CreateTargetGroupRequest) (*connection.APIResponseBodyData[TargetGroup], error) {
-	body := &connection.APIResponseBodyData[TargetGroup]{}
-
-	response, err := s.connection.Post("/loadbalancers/v2/target-groups", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body)
 }
 
 // PatchTargetGroup patches a target group
 func (s *Service) PatchTargetGroup(groupID int, req PatchTargetGroupRequest) error {
-	_, err := s.patchTargetGroupResponseBody(groupID, req)
-
-	return err
-}
-
-func (s *Service) patchTargetGroupResponseBody(groupID int, req PatchTargetGroupRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if groupID < 1 {
-		return body, fmt.Errorf("invalid target group id")
+		return fmt.Errorf("invalid target group id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/loadbalancers/v2/target-groups/%d", groupID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TargetGroupNotFoundError{ID: groupID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d", groupID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TargetGroupNotFoundError{ID: groupID}))
 }
 
-// PatchTargetGroup patches a target group
+// DeleteTargetGroup deletes a target group
 func (s *Service) DeleteTargetGroup(groupID int) error {
-	_, err := s.deleteTargetGroupResponseBody(groupID)
-
-	return err
-}
-
-func (s *Service) deleteTargetGroupResponseBody(groupID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if groupID < 1 {
-		return body, fmt.Errorf("invalid target group id")
+		return fmt.Errorf("invalid target group id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/loadbalancers/v2/target-groups/%d", groupID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TargetGroupNotFoundError{ID: groupID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d", groupID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TargetGroupNotFoundError{ID: groupID}))
 }

--- a/pkg/service/loadbalancer/service_targetgroup_acl.go
+++ b/pkg/service/loadbalancer/service_targetgroup_acl.go
@@ -15,24 +15,11 @@ func (s *Service) GetTargetGroupACLs(targetGroupID int, parameters connection.AP
 
 // GetTargetGroupACLsPaginated retrieves a paginated list of ACLs
 func (s *Service) GetTargetGroupACLsPaginated(targetGroupID int, parameters connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
-	body, err := s.getTargetGroupACLsPaginatedResponseBody(targetGroupID, parameters)
-
+	if targetGroupID < 1 {
+		return nil, fmt.Errorf("invalid target group id")
+	}
+	body, err := connection.Get[[]ACL](s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/acls", targetGroupID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
 		return s.GetTargetGroupACLsPaginated(targetGroupID, p)
 	}), err
-}
-
-func (s *Service) getTargetGroupACLsPaginatedResponseBody(targetGroupID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ACL], error) {
-	body := &connection.APIResponseBodyData[[]ACL]{}
-
-	if targetGroupID < 1 {
-		return body, fmt.Errorf("invalid target group id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/target-groups/%d/acls", targetGroupID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/loadbalancer/service_targetgroup_target.go
+++ b/pkg/service/loadbalancer/service_targetgroup_target.go
@@ -15,148 +15,54 @@ func (s *Service) GetTargetGroupTargets(groupID int, parameters connection.APIRe
 
 // GetTargetGroupTargetsPaginated retrieves a paginated list of targets
 func (s *Service) GetTargetGroupTargetsPaginated(groupID int, parameters connection.APIRequestParameters) (*connection.Paginated[Target], error) {
-	body, err := s.getTargetGroupTargetsPaginatedResponseBody(groupID, parameters)
-
+	if groupID < 1 {
+		return nil, fmt.Errorf("invalid target group id")
+	}
+	body, err := connection.Get[[]Target](s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets", groupID), parameters)
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Target], error) {
 		return s.GetTargetGroupTargetsPaginated(groupID, p)
 	}), err
 }
 
-func (s *Service) getTargetGroupTargetsPaginatedResponseBody(groupID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Target], error) {
-	body := &connection.APIResponseBodyData[[]Target]{}
-
-	if groupID < 1 {
-		return body, fmt.Errorf("invalid target group id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets", groupID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
-}
-
 // GetTargetGroupTarget retrieves a single target by id
 func (s *Service) GetTargetGroupTarget(groupID int, targetID int) (Target, error) {
-	body, err := s.getTargetGroupTargetResponseBody(groupID, targetID)
-
-	return body.Data, err
-}
-
-func (s *Service) getTargetGroupTargetResponseBody(groupID int, targetID int) (*connection.APIResponseBodyData[Target], error) {
-	body := &connection.APIResponseBodyData[Target]{}
-
 	if groupID < 1 {
-		return body, fmt.Errorf("invalid target group id")
+		return Target{}, fmt.Errorf("invalid target group id")
 	}
-
 	if targetID < 1 {
-		return body, fmt.Errorf("invalid target id")
+		return Target{}, fmt.Errorf("invalid target id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets/%d", groupID, targetID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TargetNotFoundError{ID: groupID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Target](s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets/%d", groupID, targetID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TargetNotFoundError{ID: groupID}))
+	return body.Data, err
 }
 
 // CreateTargetGroupTarget creates a target
 func (s *Service) CreateTargetGroupTarget(groupID int, req CreateTargetRequest) (int, error) {
-	body, err := s.createTargetGroupTargetResponseBody(groupID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createTargetGroupTargetResponseBody(groupID int, req CreateTargetRequest) (*connection.APIResponseBodyData[Target], error) {
-	body := &connection.APIResponseBodyData[Target]{}
-
 	if groupID < 1 {
-		return body, fmt.Errorf("invalid target group id")
+		return 0, fmt.Errorf("invalid target group id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets", groupID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TargetNotFoundError{ID: groupID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[Target](s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets", groupID), &req, connection.NotFoundResponseHandler(&TargetNotFoundError{ID: groupID}))
+	return body.Data.ID, err
 }
 
 // PatchTargetGroupTarget patches a target
 func (s *Service) PatchTargetGroupTarget(groupID int, targetID int, req PatchTargetRequest) error {
-	_, err := s.patchTargetGroupTargetResponseBody(groupID, targetID, req)
-
-	return err
-}
-
-func (s *Service) patchTargetGroupTargetResponseBody(groupID int, targetID int, req PatchTargetRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if groupID < 1 {
-		return body, fmt.Errorf("invalid target group id")
+		return fmt.Errorf("invalid target group id")
 	}
-
 	if targetID < 1 {
-		return body, fmt.Errorf("invalid target id")
+		return fmt.Errorf("invalid target id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets/%d", groupID, targetID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TargetNotFoundError{ID: groupID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets/%d", groupID, targetID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TargetNotFoundError{ID: groupID}))
 }
 
 // DeleteTargetGroupTarget deletes a target
 func (s *Service) DeleteTargetGroupTarget(groupID int, targetID int) error {
-	_, err := s.deleteTargetGroupTargetResponseBody(groupID, targetID)
-
-	return err
-}
-
-func (s *Service) deleteTargetGroupTargetResponseBody(groupID int, targetID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if groupID < 1 {
-		return body, fmt.Errorf("invalid target group id")
+		return fmt.Errorf("invalid target group id")
 	}
-
 	if targetID < 1 {
-		return body, fmt.Errorf("invalid target id")
+		return fmt.Errorf("invalid target id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets/%d", groupID, targetID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TargetNotFoundError{ID: groupID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets/%d", groupID, targetID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TargetNotFoundError{ID: groupID}))
 }

--- a/pkg/service/loadbalancer/service_vip.go
+++ b/pkg/service/loadbalancer/service_vip.go
@@ -13,45 +13,15 @@ func (s *Service) GetVIPs(parameters connection.APIRequestParameters) ([]VIP, er
 
 // GetVIPsPaginated retrieves a paginated list of VIPs
 func (s *Service) GetVIPsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[VIP], error) {
-	body, err := s.getVIPsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]VIP](s.connection, "/loadbalancers/v2/vips", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVIPsPaginated), err
-}
-
-func (s *Service) getVIPsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]VIP], error) {
-	body := &connection.APIResponseBodyData[[]VIP]{}
-
-	response, err := s.connection.Get("/loadbalancers/v2/vips", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVIP retrieves a single VIP by id
 func (s *Service) GetVIP(vipID int) (VIP, error) {
-	body, err := s.getVIPResponseBody(vipID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVIPResponseBody(vipID int) (*connection.APIResponseBodyData[VIP], error) {
-	body := &connection.APIResponseBodyData[VIP]{}
-
 	if vipID < 1 {
-		return body, fmt.Errorf("invalid vip id")
+		return VIP{}, fmt.Errorf("invalid vip id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/loadbalancers/v2/vips/%d", vipID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VIPNotFoundError{ID: vipID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[VIP](s.connection, fmt.Sprintf("/loadbalancers/v2/vips/%d", vipID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VIPNotFoundError{ID: vipID}))
+	return body.Data, err
 }

--- a/pkg/service/pss/service_case.go
+++ b/pkg/service/pss/service_case.go
@@ -14,40 +14,24 @@ func (s *Service) GetCases(parameters connection.APIRequestParameters) ([]Case, 
 
 // GetCasesPaginated retrieves a paginated list of cases
 func (s *Service) GetCasesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Case], error) {
-	body, err := s.getCasesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Case](s.connection, "/pss/v2/cases", parameters)
 	return connection.NewPaginated(body, parameters, s.GetCasesPaginated), err
-}
-
-func (s *Service) getCasesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Case], error) {
-	return connection.Get[[]Case](s.connection, "/pss/v2/cases", parameters)
 }
 
 // GetCase retrieves a single instance case by id
 func (s *Service) GetCase(caseID string) (Case, error) {
-	body, err := s.getCaseResponseBody(caseID)
-
-	return body.Data, err
-}
-
-func (s *Service) getCaseResponseBody(caseID string) (*connection.APIResponseBodyData[Case], error) {
 	if caseID == "" {
-		return &connection.APIResponseBodyData[Case]{}, fmt.Errorf("invalid case id")
+		return Case{}, fmt.Errorf("invalid case id")
 	}
-
-	return connection.Get[Case](s.connection, fmt.Sprintf("/pss/v2/cases/%s", caseID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: caseID}))
+	body, err := connection.Get[Case](s.connection, fmt.Sprintf("/pss/v2/cases/%s", caseID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: caseID}))
+	return body.Data, err
 }
 
 // CreateIncidentCase creates a incident case
 func (s *Service) CreateIncidentCase(req CreateIncidentCaseRequest) (string, error) {
-	body, err := s.createIncidentCaseResponseBody(req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createIncidentCaseResponseBody(req CreateIncidentCaseRequest) (*connection.APIResponseBodyData[IncidentCase], error) {
 	req.CaseType = CaseTypeIncident
-
-	return connection.Post[IncidentCase](s.connection, "/pss/v2/cases", &req)
+	body, err := connection.Post[IncidentCase](s.connection, "/pss/v2/cases", &req)
+	return body.Data.ID, err
 }
 
 // GetIncidentCases retrieves a list of incident cases
@@ -57,69 +41,43 @@ func (s *Service) GetIncidentCases(parameters connection.APIRequestParameters) (
 
 // GetIncidentCasesPaginated retrieves a paginated list of incident cases
 func (s *Service) GetIncidentCasesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[IncidentCase], error) {
-	body, err := s.getIncidentCasesPaginatedResponseBody(parameters)
-	return connection.NewPaginated(body, parameters, s.GetIncidentCasesPaginated), err
-}
-
-func (s *Service) getIncidentCasesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]IncidentCase], error) {
 	body := &connection.APIResponseBodyData[[]IncidentCase]{}
-
 	request := connection.APIRequest{
 		Method:     "GET",
 		Resource:   "/pss/v2/cases",
 		Query:      url.Values{"case_type": []string{"incident"}},
 		Parameters: parameters,
 	}
-
 	response, err := s.connection.Invoke(request)
 	if err != nil {
-		return body, err
+		return connection.NewPaginated(body, parameters, s.GetIncidentCasesPaginated), err
 	}
-
-	return body, response.HandleResponse(body)
+	return connection.NewPaginated(body, parameters, s.GetIncidentCasesPaginated), response.HandleResponse(body)
 }
 
 // GetIncidentCase retrieves a single instance case by id
 func (s *Service) GetIncidentCase(incidentID string) (IncidentCase, error) {
-	body, err := s.getIncidentCaseResponseBody(incidentID)
-
-	return body.Data, err
-}
-
-func (s *Service) getIncidentCaseResponseBody(incidentID string) (*connection.APIResponseBodyData[IncidentCase], error) {
 	if incidentID == "" {
-		return &connection.APIResponseBodyData[IncidentCase]{}, fmt.Errorf("invalid incident id")
+		return IncidentCase{}, fmt.Errorf("invalid incident id")
 	}
-
-	return connection.Get[IncidentCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s", incidentID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: incidentID}))
+	body, err := connection.Get[IncidentCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s", incidentID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: incidentID}))
+	return body.Data, err
 }
 
 // CloseIncidentCase approves a incident case by id
 func (s *Service) CloseIncidentCase(incidentID string, req CloseIncidentCaseRequest) (string, error) {
-	body, err := s.closeIncidentCaseResponseBody(incidentID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) closeIncidentCaseResponseBody(incidentID string, req CloseIncidentCaseRequest) (*connection.APIResponseBodyData[IncidentCase], error) {
 	if incidentID == "" {
-		return &connection.APIResponseBodyData[IncidentCase]{}, fmt.Errorf("invalid incident id")
+		return "", fmt.Errorf("invalid incident id")
 	}
-
-	return connection.Post[IncidentCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s/close", incidentID), &req, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: incidentID}))
+	body, err := connection.Post[IncidentCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s/close", incidentID), &req, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: incidentID}))
+	return body.Data.ID, err
 }
 
 // CreateChangeCase creates a change case
 func (s *Service) CreateChangeCase(req CreateChangeCaseRequest) (string, error) {
-	body, err := s.createChangeCaseResponseBody(req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createChangeCaseResponseBody(req CreateChangeCaseRequest) (*connection.APIResponseBodyData[ChangeCase], error) {
 	req.CaseType = CaseTypeChange
-
-	return connection.Post[ChangeCase](s.connection, "/pss/v2/cases", &req)
+	body, err := connection.Post[ChangeCase](s.connection, "/pss/v2/cases", &req)
+	return body.Data.ID, err
 }
 
 // GetChangeCases retrieves a list of change cases
@@ -129,56 +87,36 @@ func (s *Service) GetChangeCases(parameters connection.APIRequestParameters) ([]
 
 // GetChangeCasesPaginated retrieves a paginated list of change cases
 func (s *Service) GetChangeCasesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[ChangeCase], error) {
-	body, err := s.getChangeCasesPaginatedResponseBody(parameters)
-	return connection.NewPaginated(body, parameters, s.GetChangeCasesPaginated), err
-}
-
-func (s *Service) getChangeCasesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ChangeCase], error) {
 	body := &connection.APIResponseBodyData[[]ChangeCase]{}
-
 	request := connection.APIRequest{
 		Method:     "GET",
 		Resource:   "/pss/v2/cases",
 		Query:      url.Values{"case_type": []string{"change"}},
 		Parameters: parameters,
 	}
-
 	response, err := s.connection.Invoke(request)
 	if err != nil {
-		return body, err
+		return connection.NewPaginated(body, parameters, s.GetChangeCasesPaginated), err
 	}
-
-	return body, response.HandleResponse(body)
+	return connection.NewPaginated(body, parameters, s.GetChangeCasesPaginated), response.HandleResponse(body)
 }
 
 // GetChangeCase retrieves a single instance case by id
 func (s *Service) GetChangeCase(changeID string) (ChangeCase, error) {
-	body, err := s.getChangeCaseResponseBody(changeID)
-
-	return body.Data, err
-}
-
-func (s *Service) getChangeCaseResponseBody(changeID string) (*connection.APIResponseBodyData[ChangeCase], error) {
 	if changeID == "" {
-		return &connection.APIResponseBodyData[ChangeCase]{}, fmt.Errorf("invalid change id")
+		return ChangeCase{}, fmt.Errorf("invalid change id")
 	}
-
-	return connection.Get[ChangeCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s", changeID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: changeID}))
+	body, err := connection.Get[ChangeCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s", changeID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: changeID}))
+	return body.Data, err
 }
 
 // ApproveChangeCase approves a change case by id
 func (s *Service) ApproveChangeCase(changeID string, req ApproveChangeCaseRequest) (string, error) {
-	body, err := s.approveChangeCaseResponseBody(changeID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) approveChangeCaseResponseBody(changeID string, req ApproveChangeCaseRequest) (*connection.APIResponseBodyData[ChangeCase], error) {
 	if changeID == "" {
-		return &connection.APIResponseBodyData[ChangeCase]{}, fmt.Errorf("invalid change id")
+		return "", fmt.Errorf("invalid change id")
 	}
-
-	return connection.Post[ChangeCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s/approve", changeID), &req, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: changeID}))
+	body, err := connection.Post[ChangeCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s/approve", changeID), &req, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: changeID}))
+	return body.Data.ID, err
 }
 
 // GetProblemCases retrieves a list of problem cases
@@ -188,41 +126,27 @@ func (s *Service) GetProblemCases(parameters connection.APIRequestParameters) ([
 
 // GetProblemCasesPaginated retrieves a paginated list of problem cases
 func (s *Service) GetProblemCasesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[ProblemCase], error) {
-	body, err := s.getProblemCasesPaginatedResponseBody(parameters)
-	return connection.NewPaginated(body, parameters, s.GetProblemCasesPaginated), err
-}
-
-func (s *Service) getProblemCasesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]ProblemCase], error) {
 	body := &connection.APIResponseBodyData[[]ProblemCase]{}
-
 	request := connection.APIRequest{
 		Method:     "GET",
 		Resource:   "/pss/v2/cases",
 		Query:      url.Values{"case_type": []string{"problem"}},
 		Parameters: parameters,
 	}
-
 	response, err := s.connection.Invoke(request)
 	if err != nil {
-		return body, err
+		return connection.NewPaginated(body, parameters, s.GetProblemCasesPaginated), err
 	}
-
-	return body, response.HandleResponse(body)
+	return connection.NewPaginated(body, parameters, s.GetProblemCasesPaginated), response.HandleResponse(body)
 }
 
 // GetProblemCase retrieves a single instance case by id
 func (s *Service) GetProblemCase(problemID string) (ProblemCase, error) {
-	body, err := s.getProblemCaseResponseBody(problemID)
-
-	return body.Data, err
-}
-
-func (s *Service) getProblemCaseResponseBody(problemID string) (*connection.APIResponseBodyData[ProblemCase], error) {
 	if problemID == "" {
-		return &connection.APIResponseBodyData[ProblemCase]{}, fmt.Errorf("invalid problem id")
+		return ProblemCase{}, fmt.Errorf("invalid problem id")
 	}
-
-	return connection.Get[ProblemCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s", problemID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: problemID}))
+	body, err := connection.Get[ProblemCase](s.connection, fmt.Sprintf("/pss/v2/cases/%s", problemID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: problemID}))
+	return body.Data, err
 }
 
 // GetCaseUpdates retrieves a list of problem case updates
@@ -234,50 +158,32 @@ func (s *Service) GetCaseUpdates(caseID string, parameters connection.APIRequest
 
 // GetCaseUpdatesPaginated retrieves a paginated list of case updates
 func (s *Service) GetCaseUpdatesPaginated(caseID string, parameters connection.APIRequestParameters) (*connection.Paginated[CaseUpdate], error) {
-	body, err := s.getCaseUpdatesPaginatedResponseBody(caseID, parameters)
-
+	if caseID == "" {
+		return nil, fmt.Errorf("invalid case id")
+	}
+	body, err := connection.Get[[]CaseUpdate](s.connection, fmt.Sprintf("/pss/v2/cases/%s/updates", caseID), parameters, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: caseID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[CaseUpdate], error) {
 		return s.GetCaseUpdatesPaginated(caseID, p)
 	}), err
 }
 
-func (s *Service) getCaseUpdatesPaginatedResponseBody(caseID string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]CaseUpdate], error) {
-	if caseID == "" {
-		return &connection.APIResponseBodyData[[]CaseUpdate]{}, fmt.Errorf("invalid case id")
-	}
-
-	return connection.Get[[]CaseUpdate](s.connection, fmt.Sprintf("/pss/v2/cases/%s/updates", caseID), parameters, connection.NotFoundResponseHandler(&CaseNotFoundError{ID: caseID}))
-}
-
 // GetProblemCase retrieves a single instance case by id
 func (s *Service) GetCaseUpdate(caseID string, updateID string) (CaseUpdate, error) {
-	body, err := s.getCaseUpdateResponseBody(caseID, updateID)
-
-	return body.Data, err
-}
-
-func (s *Service) getCaseUpdateResponseBody(caseID string, updateID string) (*connection.APIResponseBodyData[CaseUpdate], error) {
 	if caseID == "" {
-		return &connection.APIResponseBodyData[CaseUpdate]{}, fmt.Errorf("invalid case id")
+		return CaseUpdate{}, fmt.Errorf("invalid case id")
 	}
 	if updateID == "" {
-		return &connection.APIResponseBodyData[CaseUpdate]{}, fmt.Errorf("invalid case update id")
+		return CaseUpdate{}, fmt.Errorf("invalid case update id")
 	}
-
-	return connection.Get[CaseUpdate](s.connection, fmt.Sprintf("/pss/v2/cases/%s/updates/%s", caseID, updateID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseUpdateNotFoundError{ID: updateID}))
+	body, err := connection.Get[CaseUpdate](s.connection, fmt.Sprintf("/pss/v2/cases/%s/updates/%s", caseID, updateID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CaseUpdateNotFoundError{ID: updateID}))
+	return body.Data, err
 }
 
 // CreateCaseUpdate creates a change case
 func (s *Service) CreateCaseUpdate(caseID string, req CreateCaseUpdateRequest) (string, error) {
-	body, err := s.createCaseUpdateResponseBody(caseID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createCaseUpdateResponseBody(caseID string, req CreateCaseUpdateRequest) (*connection.APIResponseBodyData[CaseUpdate], error) {
 	if caseID == "" {
-		return &connection.APIResponseBodyData[CaseUpdate]{}, fmt.Errorf("invalid case id")
+		return "", fmt.Errorf("invalid case id")
 	}
-
-	return connection.Post[CaseUpdate](s.connection, fmt.Sprintf("/pss/v2/cases/%s/updates", caseID), &req)
+	body, err := connection.Post[CaseUpdate](s.connection, fmt.Sprintf("/pss/v2/cases/%s/updates", caseID), &req)
+	return body.Data.ID, err
 }

--- a/pkg/service/pss/service_casecategory.go
+++ b/pkg/service/pss/service_casecategory.go
@@ -9,10 +9,6 @@ func (s *Service) GetCaseCategories(parameters connection.APIRequestParameters) 
 
 // GetCaseCategoriesPaginated retrieves a paginated list of case categories
 func (s *Service) GetCaseCategoriesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[CaseCategory], error) {
-	body, err := s.getCaseCategoriesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]CaseCategory](s.connection, "/pss/v2/case-categories", parameters)
 	return connection.NewPaginated(body, parameters, s.GetCaseCategoriesPaginated), err
-}
-
-func (s *Service) getCaseCategoriesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]CaseCategory], error) {
-	return connection.Get[[]CaseCategory](s.connection, "/pss/v2/case-categories", parameters)
 }

--- a/pkg/service/pss/service_caseoption.go
+++ b/pkg/service/pss/service_caseoption.go
@@ -9,12 +9,8 @@ func (s *Service) GetChangeImpactCaseOptions(parameters connection.APIRequestPar
 
 // GetCaseOptionsPaginated retrieves a paginated list of change impact case options
 func (s *Service) GetChangeImpactCaseOptionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[CaseOption], error) {
-	body, err := s.getChangeImpactCaseOptionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]CaseOption](s.connection, "/pss/v2/case-options/change-impacts", parameters)
 	return connection.NewPaginated(body, parameters, s.GetChangeImpactCaseOptionsPaginated), err
-}
-
-func (s *Service) getChangeImpactCaseOptionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]CaseOption], error) {
-	return connection.Get[[]CaseOption](s.connection, "/pss/v2/case-options/change-impacts", parameters)
 }
 
 // GetCaseOptions retrieves a list of change risk case options
@@ -24,12 +20,8 @@ func (s *Service) GetChangeRiskCaseOptions(parameters connection.APIRequestParam
 
 // GetCaseOptionsPaginated retrieves a paginated list of change risk case options
 func (s *Service) GetChangeRiskCaseOptionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[CaseOption], error) {
-	body, err := s.getChangeRiskCaseOptionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]CaseOption](s.connection, "/pss/v2/case-options/change-risks", parameters)
 	return connection.NewPaginated(body, parameters, s.GetChangeRiskCaseOptionsPaginated), err
-}
-
-func (s *Service) getChangeRiskCaseOptionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]CaseOption], error) {
-	return connection.Get[[]CaseOption](s.connection, "/pss/v2/case-options/change-risks", parameters)
 }
 
 // GetCaseOptions retrieves a list of incident impact case options
@@ -39,12 +31,8 @@ func (s *Service) GetIncidentImpactCaseOptions(parameters connection.APIRequestP
 
 // GetCaseOptionsPaginated retrieves a paginated list of incident impact case options
 func (s *Service) GetIncidentImpactCaseOptionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[CaseOption], error) {
-	body, err := s.getIncidentImpactCaseOptionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]CaseOption](s.connection, "/pss/v2/case-options/incident-impacts", parameters)
 	return connection.NewPaginated(body, parameters, s.GetIncidentImpactCaseOptionsPaginated), err
-}
-
-func (s *Service) getIncidentImpactCaseOptionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]CaseOption], error) {
-	return connection.Get[[]CaseOption](s.connection, "/pss/v2/case-options/incident-impacts", parameters)
 }
 
 // GetCaseOptions retrieves a list of incident type case options
@@ -54,10 +42,6 @@ func (s *Service) GetIncidentTypeCaseOptions(parameters connection.APIRequestPar
 
 // GetCaseOptionsPaginated retrieves a paginated list of incident type case options
 func (s *Service) GetIncidentTypeCaseOptionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[CaseOption], error) {
-	body, err := s.getIncidentTypeCaseOptionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]CaseOption](s.connection, "/pss/v2/case-options/incident-types", parameters)
 	return connection.NewPaginated(body, parameters, s.GetIncidentTypeCaseOptionsPaginated), err
-}
-
-func (s *Service) getIncidentTypeCaseOptionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]CaseOption], error) {
-	return connection.Get[[]CaseOption](s.connection, "/pss/v2/case-options/incident-types", parameters)
 }

--- a/pkg/service/pss/service_reply.go
+++ b/pkg/service/pss/service_reply.go
@@ -9,30 +9,11 @@ import (
 
 // GetReply retrieves a single reply by id
 func (s *Service) GetReply(replyID string) (Reply, error) {
-	body, err := s.getReplyResponseBody(replyID)
-
-	return body.Data, err
-}
-
-func (s *Service) getReplyResponseBody(replyID string) (*connection.APIResponseBodyData[Reply], error) {
-	body := &connection.APIResponseBodyData[Reply]{}
-
 	if replyID == "" {
-		return body, fmt.Errorf("invalid reply id")
+		return Reply{}, fmt.Errorf("invalid reply id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/pss/v1/replies/%s", replyID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ReplyNotFoundError{ID: replyID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Reply](s.connection, fmt.Sprintf("/pss/v1/replies/%s", replyID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ReplyNotFoundError{ID: replyID}))
+	return body.Data, err
 }
 
 // DownloadReplyAttachmentStream downloads the provided attachment, returning
@@ -70,63 +51,25 @@ func (s *Service) downloadReplyAttachmentResponse(replyID string, attachmentName
 
 // UploadReplyAttachmentStream uploads the provided attachment
 func (s *Service) UploadReplyAttachmentStream(replyID string, attachmentName string, stream io.Reader) (err error) {
-	_, err = s.uploadReplyAttachmentStreamResponseBody(replyID, attachmentName, stream)
-
-	return err
-}
-
-func (s *Service) uploadReplyAttachmentStreamResponseBody(replyID string, attachmentName string, stream io.Reader) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if replyID == "" {
-		return body, fmt.Errorf("invalid reply id")
+		return fmt.Errorf("invalid reply id")
 	}
 	if attachmentName == "" {
-		return body, fmt.Errorf("invalid attachment name")
+		return fmt.Errorf("invalid attachment name")
 	}
 	if stream == nil {
-		return body, fmt.Errorf("invalid stream")
+		return fmt.Errorf("invalid stream")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/pss/v1/replies/%s/attachments/%s", replyID, attachmentName), stream)
-	if err != nil {
-		return body, err
-	}
-
-	if response.StatusCode == 404 {
-		return body, &ReplyNotFoundError{ID: replyID}
-	}
-
-	return body, response.HandleResponse(body, nil)
+	return connection.PostRaw(s.connection, fmt.Sprintf("/pss/v1/replies/%s/attachments/%s", replyID, attachmentName), stream, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ReplyNotFoundError{ID: replyID}))
 }
 
 // DeleteReplyAttachment removes a reply attachment
 func (s *Service) DeleteReplyAttachment(replyID string, attachmentName string) error {
-	_, err := s.deleteReplyAttachmentResponseBody(replyID, attachmentName)
-
-	return err
-}
-
-func (s *Service) deleteReplyAttachmentResponseBody(replyID string, attachmentName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if replyID == "" {
-		return body, fmt.Errorf("invalid reply id")
+		return fmt.Errorf("invalid reply id")
 	}
 	if attachmentName == "" {
-		return body, fmt.Errorf("invalid attachment name")
+		return fmt.Errorf("invalid attachment name")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/pss/v1/replies/%s/attachments/%s", replyID, attachmentName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &AttachmentNotFoundError{Name: attachmentName}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/pss/v1/replies/%s/attachments/%s", replyID, attachmentName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&AttachmentNotFoundError{Name: attachmentName}))
 }

--- a/pkg/service/pss/service_request.go
+++ b/pkg/service/pss/service_request.go
@@ -8,20 +8,8 @@ import (
 
 // CreateRequest creates a new request
 func (s *Service) CreateRequest(req CreateRequestRequest) (int, error) {
-	body, err := s.createRequestResponseBody(req)
-
+	body, err := connection.Post[Request](s.connection, "/pss/v1/requests", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createRequestResponseBody(req CreateRequestRequest) (*connection.APIResponseBodyData[Request], error) {
-	body := &connection.APIResponseBodyData[Request]{}
-
-	response, err := s.connection.Post("/pss/v1/requests", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetRequests retrieves a list of requests
@@ -31,103 +19,34 @@ func (s *Service) GetRequests(parameters connection.APIRequestParameters) ([]Req
 
 // GetRequestsPaginated retrieves a paginated list of requests
 func (s *Service) GetRequestsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Request], error) {
-	body, err := s.getRequestsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Request](s.connection, "/pss/v1/requests", parameters)
 	return connection.NewPaginated(body, parameters, s.GetRequestsPaginated), err
-}
-
-func (s *Service) getRequestsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Request], error) {
-	body := &connection.APIResponseBodyData[[]Request]{}
-
-	response, err := s.connection.Get("/pss/v1/requests", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetRequest retrieves a single request by id
 func (s *Service) GetRequest(requestID int) (Request, error) {
-	body, err := s.getRequestResponseBody(requestID)
-
-	return body.Data, err
-}
-
-func (s *Service) getRequestResponseBody(requestID int) (*connection.APIResponseBodyData[Request], error) {
-	body := &connection.APIResponseBodyData[Request]{}
-
 	if requestID < 1 {
-		return body, fmt.Errorf("invalid request id")
+		return Request{}, fmt.Errorf("invalid request id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/pss/v1/requests/%d", requestID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RequestNotFoundError{ID: requestID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Request](s.connection, fmt.Sprintf("/pss/v1/requests/%d", requestID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&RequestNotFoundError{ID: requestID}))
+	return body.Data, err
 }
 
 // PatchRequest patches a request
 func (s *Service) PatchRequest(requestID int, req PatchRequestRequest) error {
-	_, err := s.patchRequestResponseBody(requestID, req)
-
-	return err
-}
-
-func (s *Service) patchRequestResponseBody(requestID int, req PatchRequestRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if requestID < 1 {
-		return body, fmt.Errorf("invalid request id")
+		return fmt.Errorf("invalid request id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/pss/v1/requests/%d", requestID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RequestNotFoundError{ID: requestID}
-		}
-
-		return nil
-	})
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/pss/v1/requests/%d", requestID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&RequestNotFoundError{ID: requestID}))
 }
 
 // CreateRequestReply creates a new request reply
 func (s *Service) CreateRequestReply(requestID int, req CreateReplyRequest) (string, error) {
-	body, err := s.createRequestReplyResponseBody(requestID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createRequestReplyResponseBody(requestID int, req CreateReplyRequest) (*connection.APIResponseBodyData[Reply], error) {
-	body := &connection.APIResponseBodyData[Reply]{}
-
 	if requestID < 1 {
-		return body, fmt.Errorf("invalid request id")
+		return "", fmt.Errorf("invalid request id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/pss/v1/requests/%d/replies", requestID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RequestNotFoundError{ID: requestID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[Reply](s.connection, fmt.Sprintf("/pss/v1/requests/%d/replies", requestID), &req, connection.NotFoundResponseHandler(&RequestNotFoundError{ID: requestID}))
+	return body.Data.ID, err
 }
 
 // GetRequestReplies is an alias for GetRequestConversation
@@ -149,86 +68,29 @@ func (s *Service) GetRequestConversation(solutionID int, parameters connection.A
 
 // GetRequestConversationPaginated retrieves a paginated list of domains
 func (s *Service) GetRequestConversationPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[Reply], error) {
-	body, err := s.getRequestConversationPaginatedResponseBody(solutionID, parameters)
-
+	if solutionID < 1 {
+		return nil, fmt.Errorf("invalid request id")
+	}
+	body, err := connection.Get[[]Reply](s.connection, fmt.Sprintf("/pss/v1/requests/%d/conversation", solutionID), parameters, connection.NotFoundResponseHandler(&RequestNotFoundError{ID: solutionID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Reply], error) {
 		return s.GetRequestConversationPaginated(solutionID, p)
 	}), err
 }
 
-func (s *Service) getRequestConversationPaginatedResponseBody(requestID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Reply], error) {
-	body := &connection.APIResponseBodyData[[]Reply]{}
-
-	if requestID < 1 {
-		return body, fmt.Errorf("invalid request id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/pss/v1/requests/%d/conversation", requestID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RequestNotFoundError{ID: requestID}
-		}
-
-		return nil
-	})
-}
-
 // GetRequestFeedback retrieves feedback for a request
 func (s *Service) GetRequestFeedback(requestID int) (Feedback, error) {
-	body, err := s.getRequestFeedbackResponseBody(requestID)
-
-	return body.Data, err
-}
-
-func (s *Service) getRequestFeedbackResponseBody(requestID int) (*connection.APIResponseBodyData[Feedback], error) {
-	body := &connection.APIResponseBodyData[Feedback]{}
-
 	if requestID < 1 {
-		return body, fmt.Errorf("invalid request id")
+		return Feedback{}, fmt.Errorf("invalid request id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/pss/v1/requests/%d/feedback", requestID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RequestFeedbackNotFoundError{RequestID: requestID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Feedback](s.connection, fmt.Sprintf("/pss/v1/requests/%d/feedback", requestID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&RequestFeedbackNotFoundError{RequestID: requestID}))
+	return body.Data, err
 }
 
 // CreateRequestFeedback creates a new request feedback
 func (s *Service) CreateRequestFeedback(requestID int, req CreateFeedbackRequest) (int, error) {
-	body, err := s.createRequestFeedbackResponseBody(requestID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createRequestFeedbackResponseBody(requestID int, req CreateFeedbackRequest) (*connection.APIResponseBodyData[Feedback], error) {
-	body := &connection.APIResponseBodyData[Feedback]{}
-
 	if requestID < 1 {
-		return body, fmt.Errorf("invalid request id")
+		return 0, fmt.Errorf("invalid request id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/pss/v1/requests/%d/feedback", requestID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &RequestNotFoundError{ID: requestID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[Feedback](s.connection, fmt.Sprintf("/pss/v1/requests/%d/feedback", requestID), &req, connection.NotFoundResponseHandler(&RequestNotFoundError{ID: requestID}))
+	return body.Data.ID, err
 }

--- a/pkg/service/pss/service_supportedservice.go
+++ b/pkg/service/pss/service_supportedservice.go
@@ -9,10 +9,6 @@ func (s *Service) GetSupportedServices(parameters connection.APIRequestParameter
 
 // GetSupportedServicesPaginated retrieves a paginated list of supported services
 func (s *Service) GetSupportedServicesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[SupportedService], error) {
-	body, err := s.getSupportedServicesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]SupportedService](s.connection, "/pss/v2/supported-services", parameters)
 	return connection.NewPaginated(body, parameters, s.GetSupportedServicesPaginated), err
-}
-
-func (s *Service) getSupportedServicesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]SupportedService], error) {
-	return connection.Get[[]SupportedService](s.connection, "/pss/v2/supported-services", parameters)
 }

--- a/pkg/service/registrar/service_domain.go
+++ b/pkg/service/registrar/service_domain.go
@@ -13,73 +13,24 @@ func (s *Service) GetDomains(parameters connection.APIRequestParameters) ([]Doma
 
 // GetDomainsPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Domain], error) {
-	body, err := s.getDomainsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Domain](s.connection, "/registrar/v1/domains", parameters)
 	return connection.NewPaginated(body, parameters, s.GetDomainsPaginated), err
-}
-
-func (s *Service) getDomainsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Domain], error) {
-	body := &connection.APIResponseBodyData[[]Domain]{}
-
-	response, err := s.connection.Get("/registrar/v1/domains", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetDomain retrieves a single domain by name
 func (s *Service) GetDomain(domainName string) (Domain, error) {
-	body, err := s.getDomainResponseBody(domainName)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainResponseBody(domainName string) (*connection.APIResponseBodyData[Domain], error) {
-	body := &connection.APIResponseBodyData[Domain]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return Domain{}, fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/registrar/v1/domains/%s", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Domain](s.connection, fmt.Sprintf("/registrar/v1/domains/%s", domainName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data, err
 }
 
 // GetDomainNameservers retrieves the nameservers for a domain
 func (s *Service) GetDomainNameservers(domainName string) ([]Nameserver, error) {
-	body, err := s.getDomainNameserversResponseBody(domainName)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainNameserversResponseBody(domainName string) (*connection.APIResponseBodyData[[]Nameserver], error) {
-	body := &connection.APIResponseBodyData[[]Nameserver]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return []Nameserver{}, fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/registrar/v1/domains/%s/nameservers", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[[]Nameserver](s.connection, fmt.Sprintf("/registrar/v1/domains/%s/nameservers", domainName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data, err
 }

--- a/pkg/service/registrar/service_whois.go
+++ b/pkg/service/registrar/service_whois.go
@@ -8,56 +8,18 @@ import (
 
 // GetWhois retrieves WHOIS information for a single domain
 func (s *Service) GetWhois(domainName string) (Whois, error) {
-	body, err := s.getWhoisResponseBody(domainName)
-
-	return body.Data, err
-}
-
-func (s *Service) getWhoisResponseBody(domainName string) (*connection.APIResponseBodyData[Whois], error) {
-	body := &connection.APIResponseBodyData[Whois]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return Whois{}, fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/registrar/v1/whois/%s", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Whois](s.connection, fmt.Sprintf("/registrar/v1/whois/%s", domainName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data, err
 }
 
 // GetWhoisRaw retrieves raw WHOIS information for a single domain
 func (s *Service) GetWhoisRaw(domainName string) (string, error) {
-	body, err := s.getWhoisRawResponseBody(domainName)
-
-	return body.Data, err
-}
-
-func (s *Service) getWhoisRawResponseBody(domainName string) (*connection.APIResponseBodyStringData, error) {
-	body := &connection.APIResponseBodyStringData{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return "", fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/registrar/v1/whois/%s/raw", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{Name: domainName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[string](s.connection, fmt.Sprintf("/registrar/v1/whois/%s/raw", domainName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
+	return body.Data, err
 }

--- a/pkg/service/safedns/service_settings.go
+++ b/pkg/service/safedns/service_settings.go
@@ -6,18 +6,6 @@ import (
 
 // GetSettings retrieves account settings
 func (s *Service) GetSettings() (Settings, error) {
-	body, err := s.getSettingsResponseBody()
-
+	body, err := connection.Get[Settings](s.connection, "/safedns/v1/settings", connection.APIRequestParameters{})
 	return body.Data, err
-}
-
-func (s *Service) getSettingsResponseBody() (*connection.APIResponseBodyData[Settings], error) {
-	body := &connection.APIResponseBodyData[Settings]{}
-
-	response, err := s.connection.Get("/safedns/v1/settings", connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/safedns/service_template.go
+++ b/pkg/service/safedns/service_template.go
@@ -13,121 +13,40 @@ func (s *Service) GetTemplates(parameters connection.APIRequestParameters) ([]Te
 
 // GetTemplatesPaginated retrieves a paginated list of templates
 func (s *Service) GetTemplatesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Template], error) {
-	body, err := s.getTemplatesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Template](s.connection, "/safedns/v1/templates", parameters)
 	return connection.NewPaginated(body, parameters, s.GetTemplatesPaginated), err
-}
-
-func (s *Service) getTemplatesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Template], error) {
-	body := &connection.APIResponseBodyData[[]Template]{}
-
-	response, err := s.connection.Get("/safedns/v1/templates", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetTemplate retrieves a single template by ID
 func (s *Service) GetTemplate(templateID int) (Template, error) {
-	body, err := s.getTemplateResponseBody(templateID)
-
-	return body.Data, err
-}
-
-func (s *Service) getTemplateResponseBody(templateID int) (*connection.APIResponseBodyData[Template], error) {
-	body := &connection.APIResponseBodyData[Template]{}
-
 	if templateID < 1 {
-		return body, fmt.Errorf("invalid template id")
+		return Template{}, fmt.Errorf("invalid template id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/safedns/v1/templates/%d", templateID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{TemplateID: templateID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Template](s.connection, fmt.Sprintf("/safedns/v1/templates/%d", templateID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TemplateNotFoundError{TemplateID: templateID}))
+	return body.Data, err
 }
 
 // CreateTemplate creates a new SafeDNS template
 func (s *Service) CreateTemplate(req CreateTemplateRequest) (int, error) {
-	body, err := s.createTemplateResponseBody(req)
-
+	body, err := connection.Post[Template](s.connection, "/safedns/v1/templates", &req)
 	return body.Data.ID, err
-}
-
-func (s *Service) createTemplateResponseBody(req CreateTemplateRequest) (*connection.APIResponseBodyData[Template], error) {
-	body := &connection.APIResponseBodyData[Template]{}
-
-	response, err := s.connection.Post("/safedns/v1/templates", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // PatchTemplate patches a SafeDNS template
 func (s *Service) PatchTemplate(templateID int, patch PatchTemplateRequest) (int, error) {
-	body, err := s.patchTemplateResponseBody(templateID, patch)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) patchTemplateResponseBody(templateID int, patch PatchTemplateRequest) (*connection.APIResponseBodyData[Template], error) {
-	body := &connection.APIResponseBodyData[Template]{}
-
 	if templateID < 1 {
-		return body, fmt.Errorf("invalid template id")
+		return 0, fmt.Errorf("invalid template id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/safedns/v1/templates/%d", templateID), &patch)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{TemplateID: templateID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[Template](s.connection, fmt.Sprintf("/safedns/v1/templates/%d", templateID), &patch, connection.NotFoundResponseHandler(&TemplateNotFoundError{TemplateID: templateID}))
+	return body.Data.ID, err
 }
 
 // DeleteTemplate removes a SafeDNS template
 func (s *Service) DeleteTemplate(templateID int) error {
-	_, err := s.deleteTemplateResponseBody(templateID)
-
-	return err
-}
-
-func (s *Service) deleteTemplateResponseBody(templateID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if templateID < 1 {
-		return body, fmt.Errorf("invalid template id")
+		return fmt.Errorf("invalid template id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/safedns/v1/templates/%d", templateID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{TemplateID: templateID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/safedns/v1/templates/%d", templateID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TemplateNotFoundError{TemplateID: templateID}))
 }
 
 // GetTemplateRecords retrieves a list of records
@@ -139,151 +58,55 @@ func (s *Service) GetTemplateRecords(templateID int, parameters connection.APIRe
 
 // GetTemplateRecordsPaginated retrieves a paginated list of templates
 func (s *Service) GetTemplateRecordsPaginated(templateID int, parameters connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-	body, err := s.getTemplateRecordsPaginatedResponseBody(templateID, parameters)
-
+	if templateID < 1 {
+		return nil, fmt.Errorf("invalid template id")
+	}
+	body, err := connection.Get[[]Record](s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records", templateID), parameters, connection.NotFoundResponseHandler(&TemplateNotFoundError{TemplateID: templateID}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Record], error) {
 		return s.GetTemplateRecordsPaginated(templateID, p)
 	}), err
 }
 
-func (s *Service) getTemplateRecordsPaginatedResponseBody(templateID int, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Record], error) {
-	body := &connection.APIResponseBodyData[[]Record]{}
-
-	if templateID < 1 {
-		return body, fmt.Errorf("invalid template id")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/safedns/v1/templates/%d/records", templateID), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{TemplateID: templateID}
-		}
-
-		return nil
-	})
-}
-
 // GetTemplateRecord retrieves a single zone record by ID
 func (s *Service) GetTemplateRecord(templateID int, recordID int) (Record, error) {
-	body, err := s.getTemplateRecordResponseBody(templateID, recordID)
-
-	return body.Data, err
-}
-
-func (s *Service) getTemplateRecordResponseBody(templateID int, recordID int) (*connection.APIResponseBodyData[Record], error) {
-	body := &connection.APIResponseBodyData[Record]{}
-
 	if templateID < 1 {
-		return body, fmt.Errorf("invalid template id")
+		return Record{}, fmt.Errorf("invalid template id")
 	}
 	if recordID < 1 {
-		return body, fmt.Errorf("invalid record id")
+		return Record{}, fmt.Errorf("invalid record id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/safedns/v1/templates/%d/records/%d", templateID, recordID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Record](s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records/%d", templateID, recordID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}))
+	return body.Data, err
 }
 
 // CreateTemplateRecord creates a new SafeDNS zone record
 func (s *Service) CreateTemplateRecord(templateID int, req CreateRecordRequest) (int, error) {
-	body, err := s.createTemplateRecordResponseBody(templateID, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createTemplateRecordResponseBody(templateID int, req CreateRecordRequest) (*connection.APIResponseBodyData[Template], error) {
-	body := &connection.APIResponseBodyData[Template]{}
-
 	if templateID < 1 {
-		return body, fmt.Errorf("invalid template id")
+		return 0, fmt.Errorf("invalid template id")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/safedns/v1/templates/%d/records", templateID), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateNotFoundError{TemplateID: templateID}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[Template](s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records", templateID), &req, connection.NotFoundResponseHandler(&TemplateNotFoundError{TemplateID: templateID}))
+	return body.Data.ID, err
 }
 
 // PatchTemplateRecord patches a SafeDNS template record
 func (s *Service) PatchTemplateRecord(templateID int, recordID int, patch PatchRecordRequest) (int, error) {
-	body, err := s.patchTemplateRecordResponseBody(templateID, recordID, patch)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) patchTemplateRecordResponseBody(templateID int, recordID int, patch PatchRecordRequest) (*connection.APIResponseBodyData[Template], error) {
-	body := &connection.APIResponseBodyData[Template]{}
-
 	if templateID < 1 {
-		return body, fmt.Errorf("invalid template id")
+		return 0, fmt.Errorf("invalid template id")
 	}
 	if recordID < 1 {
-		return body, fmt.Errorf("invalid record id")
+		return 0, fmt.Errorf("invalid record id")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/safedns/v1/templates/%d/records/%d", templateID, recordID), &patch)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}
-		}
-
-		return nil
-	})
+	body, err := connection.Patch[Template](s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records/%d", templateID, recordID), &patch, connection.NotFoundResponseHandler(&TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}))
+	return body.Data.ID, err
 }
 
 // DeleteTemplateRecord removes a SafeDNS template record
 func (s *Service) DeleteTemplateRecord(templateID int, recordID int) error {
-	_, err := s.deleteTemplateRecordResponseBody(templateID, recordID)
-
-	return err
-}
-
-func (s *Service) deleteTemplateRecordResponseBody(templateID int, recordID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if templateID < 1 {
-		return body, fmt.Errorf("invalid template id")
+		return fmt.Errorf("invalid template id")
 	}
 	if recordID < 1 {
-		return body, fmt.Errorf("invalid record id")
+		return fmt.Errorf("invalid record id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/safedns/v1/templates/%d/records/%d", templateID, recordID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records/%d", templateID, recordID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}))
 }

--- a/pkg/service/safedns/service_zone.go
+++ b/pkg/service/safedns/service_zone.go
@@ -13,115 +13,38 @@ func (s *Service) GetZones(parameters connection.APIRequestParameters) ([]Zone, 
 
 // GetZonesPaginated retrieves a paginated list of zones
 func (s *Service) GetZonesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Zone], error) {
-	body, err := s.getZonesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Zone](s.connection, "/safedns/v1/zones", parameters)
 	return connection.NewPaginated(body, parameters, s.GetZonesPaginated), err
-}
-
-func (s *Service) getZonesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Zone], error) {
-	body := &connection.APIResponseBodyData[[]Zone]{}
-
-	response, err := s.connection.Get("/safedns/v1/zones", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetZone retrieves a single zone by name
 func (s *Service) GetZone(zoneName string) (Zone, error) {
-	body, err := s.getZoneResponseBody(zoneName)
-
-	return body.Data, err
-}
-
-func (s *Service) getZoneResponseBody(zoneName string) (*connection.APIResponseBodyData[Zone], error) {
-	body := &connection.APIResponseBodyData[Zone]{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return Zone{}, fmt.Errorf("invalid zone name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/safedns/v1/zones/%s", zoneName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneNotFoundError{ZoneName: zoneName}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Zone](s.connection, fmt.Sprintf("/safedns/v1/zones/%s", zoneName), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
+	return body.Data, err
 }
 
 // CreateZone creates a new SafeDNS zone
 func (s *Service) CreateZone(req CreateZoneRequest) error {
-	_, err := s.createZoneResponseBody(req)
-
-	return err
-}
-
-func (s *Service) createZoneResponseBody(req CreateZoneRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
-	response, err := s.connection.Post("/safedns/v1/zones", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
+	return connection.PostRaw(s.connection, "/safedns/v1/zones", &req, &connection.APIResponseBody{})
 }
 
 // PatchZone patches a SafeDNS zone
 func (s *Service) PatchZone(zoneName string, req PatchZoneRequest) error {
-	_, err := s.patchZoneResponseBody(zoneName, req)
-
-	return err
-}
-
-func (s *Service) patchZoneResponseBody(zoneName string, req PatchZoneRequest) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return fmt.Errorf("invalid zone name")
 	}
-
-	response, err := s.connection.Patch(fmt.Sprintf("/safedns/v1/zones/%s", zoneName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
+	return connection.PatchRaw(s.connection, fmt.Sprintf("/safedns/v1/zones/%s", zoneName), &req, &connection.APIResponseBody{})
 }
 
 // DeleteZone removes a SafeDNS zone
 func (s *Service) DeleteZone(zoneName string) error {
-	_, err := s.deleteZoneResponseBody(zoneName)
-
-	return err
-}
-
-func (s *Service) deleteZoneResponseBody(zoneName string) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return fmt.Errorf("invalid zone name")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/safedns/v1/zones/%s", zoneName), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneNotFoundError{ZoneName: zoneName}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/safedns/v1/zones/%s", zoneName), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
 }
 
 // GetZoneRecords retrieves a list of records
@@ -133,184 +56,69 @@ func (s *Service) GetZoneRecords(zoneName string, parameters connection.APIReque
 
 // GetZoneRecordsPaginated retrieves a paginated list of zones
 func (s *Service) GetZoneRecordsPaginated(zoneName string, parameters connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-	body, err := s.getZoneRecordsPaginatedResponseBody(zoneName, parameters)
-
+	if zoneName == "" {
+		return nil, fmt.Errorf("invalid zone name")
+	}
+	body, err := connection.Get[[]Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records", zoneName), parameters, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Record], error) {
 		return s.GetZoneRecordsPaginated(zoneName, p)
 	}), err
 }
 
-func (s *Service) getZoneRecordsPaginatedResponseBody(zoneName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Record], error) {
-	body := &connection.APIResponseBodyData[[]Record]{}
-
-	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/safedns/v1/zones/%s/records", zoneName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneNotFoundError{ZoneName: zoneName}
-		}
-
-		return nil
-	})
-}
-
 // GetZoneRecord retrieves a single zone record by ID
 func (s *Service) GetZoneRecord(zoneName string, recordID int) (Record, error) {
-	body, err := s.getZoneRecordResponseBody(zoneName, recordID)
-
-	return body.Data, err
-}
-
-func (s *Service) getZoneRecordResponseBody(zoneName string, recordID int) (*connection.APIResponseBodyData[Record], error) {
-	body := &connection.APIResponseBodyData[Record]{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return Record{}, fmt.Errorf("invalid zone name")
 	}
 	if recordID < 1 {
-		return body, fmt.Errorf("invalid record id")
+		return Record{}, fmt.Errorf("invalid record id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, recordID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, recordID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}))
+	return body.Data, err
 }
 
 // CreateZoneRecord creates a new SafeDNS zone record
 func (s *Service) CreateZoneRecord(zoneName string, req CreateRecordRequest) (int, error) {
-	body, err := s.createZoneRecordResponseBody(zoneName, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createZoneRecordResponseBody(zoneName string, req CreateRecordRequest) (*connection.APIResponseBodyData[Record], error) {
-	body := &connection.APIResponseBodyData[Record]{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return 0, fmt.Errorf("invalid zone name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/safedns/v1/zones/%s/records", zoneName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneNotFoundError{ZoneName: zoneName}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records", zoneName), &req, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
+	return body.Data.ID, err
 }
 
 // UpdateZoneRecord updates a SafeDNS zone record
 func (s *Service) UpdateZoneRecord(zoneName string, record Record) (int, error) {
-	body, err := s.updateZoneRecordResponseBody(zoneName, record)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) updateZoneRecordResponseBody(zoneName string, record Record) (*connection.APIResponseBodyData[Record], error) {
-	body := &connection.APIResponseBodyData[Record]{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return 0, fmt.Errorf("invalid zone name")
 	}
 	if record.ID < 1 {
-		return body, fmt.Errorf("invalid record id")
+		return 0, fmt.Errorf("invalid record id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, record.ID), &record)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: record.ID}
-		}
-
-		return nil
-	})
+	body, err := connection.Put[Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, record.ID), &record, connection.NotFoundResponseHandler(&ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: record.ID}))
+	return body.Data.ID, err
 }
 
 // PatchZoneRecord patches a SafeDNS zone record
 func (s *Service) PatchZoneRecord(zoneName string, recordID int, patch PatchRecordRequest) (int, error) {
-	body, err := s.patchZoneRecordResponseBody(zoneName, recordID, patch)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) patchZoneRecordResponseBody(zoneName string, recordID int, patch PatchRecordRequest) (*connection.APIResponseBodyData[Record], error) {
-	body := &connection.APIResponseBodyData[Record]{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return 0, fmt.Errorf("invalid zone name")
 	}
 	if recordID < 1 {
-		return body, fmt.Errorf("invalid record id")
+		return 0, fmt.Errorf("invalid record id")
 	}
-
-	response, err := s.connection.Put(fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, recordID), &patch)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}
-		}
-
-		return nil
-	})
+	body, err := connection.Put[Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, recordID), &patch, connection.NotFoundResponseHandler(&ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}))
+	return body.Data.ID, err
 }
 
 // DeleteZoneRecord removes a SafeDNS zone record
 func (s *Service) DeleteZoneRecord(zoneName string, recordID int) error {
-	_, err := s.deleteZoneRecordResponseBody(zoneName, recordID)
-
-	return err
-}
-
-func (s *Service) deleteZoneRecordResponseBody(zoneName string, recordID int) (*connection.APIResponseBody, error) {
-	body := &connection.APIResponseBody{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return fmt.Errorf("invalid zone name")
 	}
 	if recordID < 1 {
-		return body, fmt.Errorf("invalid record id")
+		return fmt.Errorf("invalid record id")
 	}
-
-	response, err := s.connection.Delete(fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, recordID), nil)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}
-		}
-
-		return nil
-	})
+	return connection.DeleteRaw(s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, recordID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}))
 }
 
 // GetZoneNotes retrieves a list of notes
@@ -322,89 +130,32 @@ func (s *Service) GetZoneNotes(zoneName string, parameters connection.APIRequest
 
 // GetZoneNotesPaginated retrieves a paginated list of zones
 func (s *Service) GetZoneNotesPaginated(zoneName string, parameters connection.APIRequestParameters) (*connection.Paginated[Note], error) {
-	body, err := s.getZoneNotesPaginatedResponseBody(zoneName, parameters)
-
+	if zoneName == "" {
+		return nil, fmt.Errorf("invalid zone name")
+	}
+	body, err := connection.Get[[]Note](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/notes", zoneName), parameters, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
 	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Note], error) {
 		return s.GetZoneNotesPaginated(zoneName, p)
 	}), err
 }
 
-func (s *Service) getZoneNotesPaginatedResponseBody(zoneName string, parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Note], error) {
-	body := &connection.APIResponseBodyData[[]Note]{}
-
-	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
-	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/safedns/v1/zones/%s/notes", zoneName), parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneNotFoundError{ZoneName: zoneName}
-		}
-
-		return nil
-	})
-}
-
 // GetZoneNote retrieves a single zone note by ID
 func (s *Service) GetZoneNote(zoneName string, noteID int) (Note, error) {
-	body, err := s.getZoneNoteResponseBody(zoneName, noteID)
-
-	return body.Data, err
-}
-
-func (s *Service) getZoneNoteResponseBody(zoneName string, noteID int) (*connection.APIResponseBodyData[Note], error) {
-	body := &connection.APIResponseBodyData[Note]{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return Note{}, fmt.Errorf("invalid zone name")
 	}
 	if noteID < 1 {
-		return body, fmt.Errorf("invalid note id")
+		return Note{}, fmt.Errorf("invalid note id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/safedns/v1/zones/%s/notes/%d", zoneName, noteID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneNoteNotFoundError{ZoneName: zoneName, NoteID: noteID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Note](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/notes/%d", zoneName, noteID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ZoneNoteNotFoundError{ZoneName: zoneName, NoteID: noteID}))
+	return body.Data, err
 }
 
 // CreateZoneNote creates a new SafeDNS zone note
 func (s *Service) CreateZoneNote(zoneName string, req CreateNoteRequest) (int, error) {
-	body, err := s.createZoneNote(zoneName, req)
-
-	return body.Data.ID, err
-}
-
-func (s *Service) createZoneNote(zoneName string, req CreateNoteRequest) (*connection.APIResponseBodyData[Note], error) {
-	body := &connection.APIResponseBodyData[Note]{}
-
 	if zoneName == "" {
-		return body, fmt.Errorf("invalid zone name")
+		return 0, fmt.Errorf("invalid zone name")
 	}
-
-	response, err := s.connection.Post(fmt.Sprintf("/safedns/v1/zones/%s/notes", zoneName), &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &ZoneNotFoundError{ZoneName: zoneName}
-		}
-
-		return nil
-	})
+	body, err := connection.Post[Note](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/notes", zoneName), &req, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
+	return body.Data.ID, err
 }

--- a/pkg/service/sharedexchange/service_domain.go
+++ b/pkg/service/sharedexchange/service_domain.go
@@ -13,45 +13,15 @@ func (s *Service) GetDomains(parameters connection.APIRequestParameters) ([]Doma
 
 // GetDomainsPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Domain], error) {
-	body, err := s.getDomainsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Domain](s.connection, "/shared-exchange/v1/domains", parameters)
 	return connection.NewPaginated(body, parameters, s.GetDomainsPaginated), err
-}
-
-func (s *Service) getDomainsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Domain], error) {
-	body := &connection.APIResponseBodyData[[]Domain]{}
-
-	response, err := s.connection.Get("/shared-exchange/v1/domains", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetDomain retrieves a single domain by id
 func (s *Service) GetDomain(domainID int) (Domain, error) {
-	body, err := s.getDomainResponseBody(domainID)
-
-	return body.Data, err
-}
-
-func (s *Service) getDomainResponseBody(domainID int) (*connection.APIResponseBodyData[Domain], error) {
-	body := &connection.APIResponseBodyData[Domain]{}
-
 	if domainID < 1 {
-		return body, fmt.Errorf("invalid domain id")
+		return Domain{}, fmt.Errorf("invalid domain id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/shared-exchange/v1/domains/%d", domainID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &DomainNotFoundError{ID: domainID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Domain](s.connection, fmt.Sprintf("/shared-exchange/v1/domains/%d", domainID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainNotFoundError{ID: domainID}))
+	return body.Data, err
 }

--- a/pkg/service/ssl/service_certificate.go
+++ b/pkg/service/ssl/service_certificate.go
@@ -13,101 +13,33 @@ func (s *Service) GetCertificates(parameters connection.APIRequestParameters) ([
 
 // GetCertificatesPaginated retrieves a paginated list of certificates
 func (s *Service) GetCertificatesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Certificate], error) {
-	body, err := s.getCertificatesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Certificate](s.connection, "/ssl/v1/certificates", parameters)
 	return connection.NewPaginated(body, parameters, s.GetCertificatesPaginated), err
-}
-
-func (s *Service) getCertificatesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Certificate], error) {
-	body := &connection.APIResponseBodyData[[]Certificate]{}
-
-	response, err := s.connection.Get("/ssl/v1/certificates", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetCertificate retrieves a single certificate by id
 func (s *Service) GetCertificate(certificateID int) (Certificate, error) {
-	body, err := s.getCertificateResponseBody(certificateID)
-
-	return body.Data, err
-}
-
-func (s *Service) getCertificateResponseBody(certificateID int) (*connection.APIResponseBodyData[Certificate], error) {
-	body := &connection.APIResponseBodyData[Certificate]{}
-
 	if certificateID < 1 {
-		return body, fmt.Errorf("invalid certificate id")
+		return Certificate{}, fmt.Errorf("invalid certificate id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ssl/v1/certificates/%d", certificateID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CertificateNotFoundError{ID: certificateID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Certificate](s.connection, fmt.Sprintf("/ssl/v1/certificates/%d", certificateID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: certificateID}))
+	return body.Data, err
 }
 
 // GetCertificateContent retrieves the content of an SSL certificate
 func (s *Service) GetCertificateContent(certificateID int) (CertificateContent, error) {
-	body, err := s.getCertificateContentResponseBody(certificateID)
-
-	return body.Data, err
-}
-
-func (s *Service) getCertificateContentResponseBody(certificateID int) (*connection.APIResponseBodyData[CertificateContent], error) {
-	body := &connection.APIResponseBodyData[CertificateContent]{}
-
 	if certificateID < 1 {
-		return body, fmt.Errorf("invalid certificate id")
+		return CertificateContent{}, fmt.Errorf("invalid certificate id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ssl/v1/certificates/%d/download", certificateID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CertificateNotFoundError{ID: certificateID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[CertificateContent](s.connection, fmt.Sprintf("/ssl/v1/certificates/%d/download", certificateID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: certificateID}))
+	return body.Data, err
 }
 
 // GetCertificatePrivateKey retrieves an SSL certificate private key
 func (s *Service) GetCertificatePrivateKey(certificateID int) (CertificatePrivateKey, error) {
-	body, err := s.getCertificatePrivateKeyResponseBody(certificateID)
-
-	return body.Data, err
-}
-
-func (s *Service) getCertificatePrivateKeyResponseBody(certificateID int) (*connection.APIResponseBodyData[CertificatePrivateKey], error) {
-	body := &connection.APIResponseBodyData[CertificatePrivateKey]{}
-
 	if certificateID < 1 {
-		return body, fmt.Errorf("invalid certificate id")
+		return CertificatePrivateKey{}, fmt.Errorf("invalid certificate id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ssl/v1/certificates/%d/private-key", certificateID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &CertificateNotFoundError{ID: certificateID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[CertificatePrivateKey](s.connection, fmt.Sprintf("/ssl/v1/certificates/%d/private-key", certificateID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: certificateID}))
+	return body.Data, err
 }

--- a/pkg/service/ssl/service_recommendations.go
+++ b/pkg/service/ssl/service_recommendations.go
@@ -8,22 +8,9 @@ import (
 
 // GetRecommendations retrieves SSL recommendations for a domain
 func (s *Service) GetRecommendations(domainName string) (Recommendations, error) {
-	body, err := s.getRecommendationsResponseBody(domainName)
-
-	return body.Data, err
-}
-
-func (s *Service) getRecommendationsResponseBody(domainName string) (*connection.APIResponseBodyData[Recommendations], error) {
-	body := &connection.APIResponseBodyData[Recommendations]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return Recommendations{}, fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ssl/v1/recommendations/%s", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
+	body, err := connection.Get[Recommendations](s.connection, fmt.Sprintf("/ssl/v1/recommendations/%s", domainName), connection.APIRequestParameters{})
+	return body.Data, err
 }

--- a/pkg/service/ssl/service_report.go
+++ b/pkg/service/ssl/service_report.go
@@ -8,22 +8,9 @@ import (
 
 // GetReport retrieves a single report by id
 func (s *Service) GetReport(domainName string) (Report, error) {
-	body, err := s.getReportResponseBody(domainName)
-
-	return body.Data, err
-}
-
-func (s *Service) getReportResponseBody(domainName string) (*connection.APIResponseBodyData[Report], error) {
-	body := &connection.APIResponseBodyData[Report]{}
-
 	if domainName == "" {
-		return body, fmt.Errorf("invalid domain name")
+		return Report{}, fmt.Errorf("invalid domain name")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ssl/v1/reports/%s", domainName), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
+	body, err := connection.Get[Report](s.connection, fmt.Sprintf("/ssl/v1/reports/%s", domainName), connection.APIRequestParameters{})
+	return body.Data, err
 }

--- a/pkg/service/ssl/service_validate.go
+++ b/pkg/service/ssl/service_validate.go
@@ -4,18 +4,6 @@ import "github.com/ans-group/sdk-go/pkg/connection"
 
 // ValidateCertificate validates a certificate
 func (s *Service) ValidateCertificate(req ValidateRequest) (CertificateValidation, error) {
-	body, err := s.validateCertificateResponseBody(req)
-
+	body, err := connection.Post[CertificateValidation](s.connection, "/ssl/v1/validate", &req)
 	return body.Data, err
-}
-
-func (s *Service) validateCertificateResponseBody(req ValidateRequest) (*connection.APIResponseBodyData[CertificateValidation], error) {
-	body := &connection.APIResponseBodyData[CertificateValidation]{}
-
-	response, err := s.connection.Post("/ssl/v1/validate", &req)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }

--- a/pkg/service/storage/service_host.go
+++ b/pkg/service/storage/service_host.go
@@ -13,45 +13,15 @@ func (s *Service) GetHosts(parameters connection.APIRequestParameters) ([]Host, 
 
 // GetHostsPaginated retrieves a paginated list of hosts
 func (s *Service) GetHostsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Host], error) {
-	body, err := s.getHostsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Host](s.connection, "/ukfast-storage/v1/hosts", parameters)
 	return connection.NewPaginated(body, parameters, s.GetHostsPaginated), err
-}
-
-func (s *Service) getHostsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Host], error) {
-	body := &connection.APIResponseBodyData[[]Host]{}
-
-	response, err := s.connection.Get("/ukfast-storage/v1/hosts", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetHost retrieves a single host by id
 func (s *Service) GetHost(hostID int) (Host, error) {
-	body, err := s.getHostResponseBody(hostID)
-
-	return body.Data, err
-}
-
-func (s *Service) getHostResponseBody(hostID int) (*connection.APIResponseBodyData[Host], error) {
-	body := &connection.APIResponseBodyData[Host]{}
-
 	if hostID < 1 {
-		return body, fmt.Errorf("invalid host id")
+		return Host{}, fmt.Errorf("invalid host id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ukfast-storage/v1/hosts/%d", hostID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &HostNotFoundError{ID: hostID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Host](s.connection, fmt.Sprintf("/ukfast-storage/v1/hosts/%d", hostID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&HostNotFoundError{ID: hostID}))
+	return body.Data, err
 }

--- a/pkg/service/storage/service_solution.go
+++ b/pkg/service/storage/service_solution.go
@@ -13,45 +13,15 @@ func (s *Service) GetSolutions(parameters connection.APIRequestParameters) ([]So
 
 // GetSolutionsPaginated retrieves a paginated list of solutions
 func (s *Service) GetSolutionsPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Solution], error) {
-	body, err := s.getSolutionsPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Solution](s.connection, "/ukfast-storage/v1/solutions", parameters)
 	return connection.NewPaginated(body, parameters, s.GetSolutionsPaginated), err
-}
-
-func (s *Service) getSolutionsPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Solution], error) {
-	body := &connection.APIResponseBodyData[[]Solution]{}
-
-	response, err := s.connection.Get("/ukfast-storage/v1/solutions", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetSolution retrieves a single solution by id
 func (s *Service) GetSolution(solutionID int) (Solution, error) {
-	body, err := s.getSolutionResponseBody(solutionID)
-
-	return body.Data, err
-}
-
-func (s *Service) getSolutionResponseBody(solutionID int) (*connection.APIResponseBodyData[Solution], error) {
-	body := &connection.APIResponseBodyData[Solution]{}
-
 	if solutionID < 1 {
-		return body, fmt.Errorf("invalid solution id")
+		return Solution{}, fmt.Errorf("invalid solution id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ukfast-storage/v1/solutions/%d", solutionID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &SolutionNotFoundError{ID: solutionID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Solution](s.connection, fmt.Sprintf("/ukfast-storage/v1/solutions/%d", solutionID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
+	return body.Data, err
 }

--- a/pkg/service/storage/service_volume.go
+++ b/pkg/service/storage/service_volume.go
@@ -13,45 +13,15 @@ func (s *Service) GetVolumes(parameters connection.APIRequestParameters) ([]Volu
 
 // GetVolumesPaginated retrieves a paginated list of volumes
 func (s *Service) GetVolumesPaginated(parameters connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-	body, err := s.getVolumesPaginatedResponseBody(parameters)
+	body, err := connection.Get[[]Volume](s.connection, "/ukfast-storage/v1/volumes", parameters)
 	return connection.NewPaginated(body, parameters, s.GetVolumesPaginated), err
-}
-
-func (s *Service) getVolumesPaginatedResponseBody(parameters connection.APIRequestParameters) (*connection.APIResponseBodyData[[]Volume], error) {
-	body := &connection.APIResponseBodyData[[]Volume]{}
-
-	response, err := s.connection.Get("/ukfast-storage/v1/volumes", parameters)
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, nil)
 }
 
 // GetVolume retrieves a single volume by id
 func (s *Service) GetVolume(volumeID int) (Volume, error) {
-	body, err := s.getVolumeResponseBody(volumeID)
-
-	return body.Data, err
-}
-
-func (s *Service) getVolumeResponseBody(volumeID int) (*connection.APIResponseBodyData[Volume], error) {
-	body := &connection.APIResponseBodyData[Volume]{}
-
 	if volumeID < 1 {
-		return body, fmt.Errorf("invalid volume id")
+		return Volume{}, fmt.Errorf("invalid volume id")
 	}
-
-	response, err := s.connection.Get(fmt.Sprintf("/ukfast-storage/v1/volumes/%d", volumeID), connection.APIRequestParameters{})
-	if err != nil {
-		return body, err
-	}
-
-	return body, response.HandleResponse(body, func(resp *connection.APIResponse) error {
-		if response.StatusCode == 404 {
-			return &VolumeNotFoundError{ID: volumeID}
-		}
-
-		return nil
-	})
+	body, err := connection.Get[Volume](s.connection, fmt.Sprintf("/ukfast-storage/v1/volumes/%d", volumeID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&VolumeNotFoundError{ID: volumeID}))
+	return body.Data, err
 }


### PR DESCRIPTION
Each public service method previously delegated to a private getXxxResponseBody/createXxxResponseBody/etc. method that did nothing but allocate a response body struct, call the connection, and invoke HandleResponse. These private methods are now eliminated: public methods call connection.Get[T]/Post[T]/PatchRaw/DeleteRaw/PutRaw directly, and inline 404 handling via the existing connection.NotFoundResponseHandler.

117 files changed, ~9300 net lines deleted. No public API changes.