### PR TITLE
refactor: introduce SubResource/SubResourceList abstractions

### DIFF
--- a/pkg/service/ddosx/service_domain.go
+++ b/pkg/service/ddosx/service_domain.go
@@ -14,6 +14,75 @@ func (s *Service) domainRes() *resource.Resource[Domain, string] {
 		func(id string) error { return &DomainNotFoundError{Name: id} })
 }
 
+func (s *Service) domainRecordRes() *resource.SubResource[Record, string, string] {
+	return resource.NewStringStringSubResource[Record](s.connection,
+		func(domainName string) string { return fmt.Sprintf("/ddosx/v1/domains/%s/records", domainName) },
+		"domain", "name", func(domainName string) error { return &DomainNotFoundError{Name: domainName} },
+		"record", "ID", func(domainName, recordID string) error {
+			return &DomainRecordNotFoundError{DomainName: domainName, ID: recordID}
+		})
+}
+
+func (s *Service) domainPropertyRes() *resource.SubResource[DomainProperty, string, string] {
+	return resource.NewStringStringSubResource[DomainProperty](s.connection,
+		func(domainName string) string { return fmt.Sprintf("/ddosx/v1/domains/%s/properties", domainName) },
+		"domain", "name", func(domainName string) error { return &DomainNotFoundError{Name: domainName} },
+		"property", "ID", func(_, propertyID string) error { return &DomainPropertyNotFoundError{ID: propertyID} })
+}
+
+func (s *Service) domainWAFRuleSetRes() *resource.SubResource[WAFRuleSet, string, string] {
+	return resource.NewStringStringSubResource[WAFRuleSet](s.connection,
+		func(domainName string) string { return fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets", domainName) },
+		"domain", "name", func(domainName string) error { return &DomainNotFoundError{Name: domainName} },
+		"rule set", "ID", func(_, ruleSetID string) error { return &WAFRuleSetNotFoundError{ID: ruleSetID} })
+}
+
+func (s *Service) domainWAFRuleRes() *resource.SubResource[WAFRule, string, string] {
+	return resource.NewStringStringSubResource[WAFRule](s.connection,
+		func(domainName string) string { return fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules", domainName) },
+		"domain", "name", func(domainName string) error { return &DomainNotFoundError{Name: domainName} },
+		"rule", "ID", func(_, ruleID string) error { return &WAFRuleNotFoundError{ID: ruleID} })
+}
+
+func (s *Service) domainWAFAdvancedRuleRes() *resource.SubResource[WAFAdvancedRule, string, string] {
+	return resource.NewStringStringSubResource[WAFAdvancedRule](s.connection,
+		func(domainName string) string {
+			return fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules", domainName)
+		},
+		"domain", "name", func(domainName string) error { return &DomainNotFoundError{Name: domainName} },
+		"rule", "ID", func(_, ruleID string) error { return &WAFAdvancedRuleNotFoundError{ID: ruleID} })
+}
+
+func (s *Service) domainACLGeoIPRuleRes() *resource.SubResource[ACLGeoIPRule, string, string] {
+	return resource.NewStringStringSubResource[ACLGeoIPRule](s.connection,
+		func(domainName string) string { return fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips", domainName) },
+		"domain", "name", func(domainName string) error { return &DomainNotFoundError{Name: domainName} },
+		"rule", "ID", func(_, ruleID string) error { return &ACLGeoIPRuleNotFoundError{ID: ruleID} })
+}
+
+func (s *Service) domainACLIPRuleRes() *resource.SubResource[ACLIPRule, string, string] {
+	return resource.NewStringStringSubResource[ACLIPRule](s.connection,
+		func(domainName string) string { return fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips", domainName) },
+		"domain", "name", func(domainName string) error { return &DomainNotFoundError{Name: domainName} },
+		"rule", "ID", func(_, ruleID string) error { return &ACLIPRuleNotFoundError{ID: ruleID} })
+}
+
+func (s *Service) domainCDNRuleRes() *resource.SubResource[CDNRule, string, string] {
+	return resource.NewStringStringSubResource[CDNRule](s.connection,
+		func(domainName string) string { return fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules", domainName) },
+		"domain", "name",
+		func(domainName string) error { return &DomainCDNConfigurationNotFoundError{DomainName: domainName} },
+		"rule", "ID", func(_, ruleID string) error { return &CDNRuleNotFoundError{ID: ruleID} })
+}
+
+func (s *Service) domainHSTSRuleRes() *resource.SubResource[HSTSRule, string, string] {
+	return resource.NewStringStringSubResource[HSTSRule](s.connection,
+		func(domainName string) string { return fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules", domainName) },
+		"domain", "name",
+		func(domainName string) error { return &DomainHSTSConfigurationNotFoundError{DomainName: domainName} },
+		"rule", "ID", func(_, ruleID string) error { return &HSTSRuleNotFoundError{ID: ruleID} })
+}
+
 // GetDomains retrieves a list of domains
 func (s *Service) GetDomains(parameters connection.APIRequestParameters) ([]Domain, error) {
 	return s.domainRes().List(parameters)
@@ -53,104 +122,53 @@ func (s *Service) DeployDomain(domainName string) error {
 
 // GetDomainRecords retrieves a list of records
 func (s *Service) GetDomainRecords(domainName string, parameters connection.APIRequestParameters) ([]Record, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-		return s.GetDomainRecordsPaginated(domainName, p)
-	}, parameters)
+	return s.domainRecordRes().List(domainName, parameters)
 }
 
 // GetDomainRecordsPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainRecordsPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-	if domainName == "" {
-		return nil, fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Get[[]Record](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records", domainName), parameters, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-		return s.GetDomainRecordsPaginated(domainName, p)
-	}), err
+	return s.domainRecordRes().ListPaginated(domainName, parameters)
 }
 
 // GetDomainRecord retrieves a single domain record by ID
 func (s *Service) GetDomainRecord(domainName string, recordID string) (Record, error) {
-	if domainName == "" {
-		return Record{}, fmt.Errorf("invalid domain name")
-	}
-	if recordID == "" {
-		return Record{}, fmt.Errorf("invalid record ID")
-	}
-	body, err := connection.Get[Record](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records/%s", domainName, recordID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainRecordNotFoundError{DomainName: domainName, ID: recordID}))
-	return body.Data, err
+	return s.domainRecordRes().Get(domainName, recordID)
 }
 
 // CreateDomainRecord creates a new record for a domain
 func (s *Service) CreateDomainRecord(domainName string, req CreateRecordRequest) (string, error) {
-	if domainName == "" {
-		return "", fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Post[Record](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
-	return body.Data.ID, err
+	record, err := s.domainRecordRes().Create(domainName, &req)
+	return record.ID, err
 }
 
 // PatchDomainRecord patches a single domain record by ID
 func (s *Service) PatchDomainRecord(domainName string, recordID string, req PatchRecordRequest) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if recordID == "" {
-		return fmt.Errorf("invalid record ID")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records/%s", domainName, recordID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainRecordNotFoundError{ID: recordID}))
+	return s.domainRecordRes().Patch(domainName, recordID, &req)
 }
 
 // DeleteDomainRecord deletes a single domain record by ID
 func (s *Service) DeleteDomainRecord(domainName string, recordID string) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if recordID == "" {
-		return fmt.Errorf("invalid record ID")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/records/%s", domainName, recordID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainRecordNotFoundError{ID: recordID}))
+	return s.domainRecordRes().Delete(domainName, recordID)
 }
 
 // GetDomainProperties retrieves a list of domain properties
 func (s *Service) GetDomainProperties(domainName string, parameters connection.APIRequestParameters) ([]DomainProperty, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[DomainProperty], error) {
-		return s.GetDomainPropertiesPaginated(domainName, p)
-	}, parameters)
+	return s.domainPropertyRes().List(domainName, parameters)
 }
 
 // GetDomainPropertiesPaginated retrieves a paginated list of domain properties
 func (s *Service) GetDomainPropertiesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[DomainProperty], error) {
-	if domainName == "" {
-		return nil, fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Get[[]DomainProperty](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/properties", domainName), parameters, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[DomainProperty], error) {
-		return s.GetDomainPropertiesPaginated(domainName, p)
-	}), err
+	return s.domainPropertyRes().ListPaginated(domainName, parameters)
 }
 
 // GetDomainProperty retrieves a single domain property by ID
 func (s *Service) GetDomainProperty(domainName string, propertyID string) (DomainProperty, error) {
-	if domainName == "" {
-		return DomainProperty{}, fmt.Errorf("invalid domain name")
-	}
-	if propertyID == "" {
-		return DomainProperty{}, fmt.Errorf("invalid property ID")
-	}
-	body, err := connection.Get[DomainProperty](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/properties/%s", domainName, propertyID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&DomainPropertyNotFoundError{ID: propertyID}))
-	return body.Data, err
+	return s.domainPropertyRes().Get(domainName, propertyID)
 }
 
 // PatchDomainProperty patches a single domain property by ID
 func (s *Service) PatchDomainProperty(domainName string, propertyID string, req PatchDomainPropertyRequest) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if propertyID == "" {
-		return fmt.Errorf("invalid property ID")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/properties/%s", domainName, propertyID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&DomainPropertyNotFoundError{ID: propertyID}))
+	return s.domainPropertyRes().Patch(domainName, propertyID, &req)
 }
 
 // GetDomainWAF retrieves the WAF configuration for a domain
@@ -188,227 +206,115 @@ func (s *Service) DeleteDomainWAF(domainName string) error {
 
 // GetDomainWAFRuleSets retrieves a list of rulesets
 func (s *Service) GetDomainWAFRuleSets(domainName string, parameters connection.APIRequestParameters) ([]WAFRuleSet, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[WAFRuleSet], error) {
-		return s.GetDomainWAFRuleSetsPaginated(domainName, p)
-	}, parameters)
+	return s.domainWAFRuleSetRes().List(domainName, parameters)
 }
 
 // GetDomainWAFRuleSetsPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainWAFRuleSetsPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[WAFRuleSet], error) {
-	if domainName == "" {
-		return nil, fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Get[[]WAFRuleSet](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets", domainName), parameters, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[WAFRuleSet], error) {
-		return s.GetDomainWAFRuleSetsPaginated(domainName, p)
-	}), err
+	return s.domainWAFRuleSetRes().ListPaginated(domainName, parameters)
 }
 
 // GetDomainWAFRuleSet retrieves a waf advanced rule set for a domain
 func (s *Service) GetDomainWAFRuleSet(domainName string, ruleSetID string) (WAFRuleSet, error) {
-	if domainName == "" {
-		return WAFRuleSet{}, fmt.Errorf("invalid domain name")
-	}
-	if ruleSetID == "" {
-		return WAFRuleSet{}, fmt.Errorf("invalid rule set ID")
-	}
-	body, err := connection.Get[WAFRuleSet](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets/%s", domainName, ruleSetID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&WAFRuleSetNotFoundError{ID: ruleSetID}))
-	return body.Data, err
+	return s.domainWAFRuleSetRes().Get(domainName, ruleSetID)
 }
 
 // PatchDomainWAFRuleSet patches a waf advanced rule set for a domain
 func (s *Service) PatchDomainWAFRuleSet(domainName string, ruleSetID string, req PatchWAFRuleSetRequest) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleSetID == "" {
-		return fmt.Errorf("invalid rule set ID")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rulesets/%s", domainName, ruleSetID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFRuleSetNotFoundError{ID: ruleSetID}))
+	return s.domainWAFRuleSetRes().Patch(domainName, ruleSetID, &req)
 }
 
 // GetDomainWAFRules retrieves a list of rules
 func (s *Service) GetDomainWAFRules(domainName string, parameters connection.APIRequestParameters) ([]WAFRule, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[WAFRule], error) {
-		return s.GetDomainWAFRulesPaginated(domainName, p)
-	}, parameters)
+	return s.domainWAFRuleRes().List(domainName, parameters)
 }
 
 // GetDomainWAFRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainWAFRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[WAFRule], error) {
-	if domainName == "" {
-		return nil, fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Get[[]WAFRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules", domainName), parameters, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[WAFRule], error) {
-		return s.GetDomainWAFRulesPaginated(domainName, p)
-	}), err
+	return s.domainWAFRuleRes().ListPaginated(domainName, parameters)
 }
 
 // GetDomainWAFRule retrieves a waf rule for a domain
 func (s *Service) GetDomainWAFRule(domainName string, ruleID string) (WAFRule, error) {
-	if domainName == "" {
-		return WAFRule{}, fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return WAFRule{}, fmt.Errorf("invalid rule ID")
-	}
-	body, err := connection.Get[WAFRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&WAFRuleNotFoundError{ID: ruleID}))
-	return body.Data, err
+	return s.domainWAFRuleRes().Get(domainName, ruleID)
 }
 
 // CreateDomainWAFRule creates a WAF rule
 func (s *Service) CreateDomainWAFRule(domainName string, req CreateWAFRuleRequest) (string, error) {
-	if domainName == "" {
-		return "", fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Post[WAFRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
-	return body.Data.ID, err
+	rule, err := s.domainWAFRuleRes().Create(domainName, &req)
+	return rule.ID, err
 }
 
 // PatchDomainWAFRule patches a waf rule for a domain
 func (s *Service) PatchDomainWAFRule(domainName string, ruleID string, req PatchWAFRuleRequest) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules/%s", domainName, ruleID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFRuleNotFoundError{ID: ruleID}))
+	return s.domainWAFRuleRes().Patch(domainName, ruleID, &req)
 }
 
 // DeleteDomainWAFRule deletes a waf rule for a domain
 func (s *Service) DeleteDomainWAFRule(domainName string, ruleID string) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/rules/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFRuleNotFoundError{ID: ruleID}))
+	return s.domainWAFRuleRes().Delete(domainName, ruleID)
 }
 
 // GetDomainWAFAdvancedRules retrieves a list of rules
 func (s *Service) GetDomainWAFAdvancedRules(domainName string, parameters connection.APIRequestParameters) ([]WAFAdvancedRule, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[WAFAdvancedRule], error) {
-		return s.GetDomainWAFAdvancedRulesPaginated(domainName, p)
-	}, parameters)
+	return s.domainWAFAdvancedRuleRes().List(domainName, parameters)
 }
 
 // GetDomainWAFAdvancedRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainWAFAdvancedRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[WAFAdvancedRule], error) {
-	if domainName == "" {
-		return nil, fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Get[[]WAFAdvancedRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules", domainName), parameters, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[WAFAdvancedRule], error) {
-		return s.GetDomainWAFAdvancedRulesPaginated(domainName, p)
-	}), err
+	return s.domainWAFAdvancedRuleRes().ListPaginated(domainName, parameters)
 }
 
 // GetDomainWAFAdvancedRule retrieves a waf rule for a domain
 func (s *Service) GetDomainWAFAdvancedRule(domainName string, ruleID string) (WAFAdvancedRule, error) {
-	if domainName == "" {
-		return WAFAdvancedRule{}, fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return WAFAdvancedRule{}, fmt.Errorf("invalid rule ID")
-	}
-	body, err := connection.Get[WAFAdvancedRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&WAFAdvancedRuleNotFoundError{ID: ruleID}))
-	return body.Data, err
+	return s.domainWAFAdvancedRuleRes().Get(domainName, ruleID)
 }
 
 // CreateDomainWAFAdvancedRule creates a WAF rule
 func (s *Service) CreateDomainWAFAdvancedRule(domainName string, req CreateWAFAdvancedRuleRequest) (string, error) {
-	if domainName == "" {
-		return "", fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Post[WAFAdvancedRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
-	return body.Data.ID, err
+	rule, err := s.domainWAFAdvancedRuleRes().Create(domainName, &req)
+	return rule.ID, err
 }
 
 // PatchDomainWAFAdvancedRule patches a waf advanced rule for a domain
 func (s *Service) PatchDomainWAFAdvancedRule(domainName string, ruleID string, req PatchWAFAdvancedRuleRequest) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules/%s", domainName, ruleID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFAdvancedRuleNotFoundError{ID: ruleID}))
+	return s.domainWAFAdvancedRuleRes().Patch(domainName, ruleID, &req)
 }
 
 // DeleteDomainWAFAdvancedRule deletees a waf advanced rule for a domain
 func (s *Service) DeleteDomainWAFAdvancedRule(domainName string, ruleID string) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/waf/advanced-rules/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&WAFAdvancedRuleNotFoundError{ID: ruleID}))
+	return s.domainWAFAdvancedRuleRes().Delete(domainName, ruleID)
 }
 
 // GetDomainACLGeoIPRules retrieves a list of rules
 func (s *Service) GetDomainACLGeoIPRules(domainName string, parameters connection.APIRequestParameters) ([]ACLGeoIPRule, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[ACLGeoIPRule], error) {
-		return s.GetDomainACLGeoIPRulesPaginated(domainName, p)
-	}, parameters)
+	return s.domainACLGeoIPRuleRes().List(domainName, parameters)
 }
 
 // GetDomainACLGeoIPRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainACLGeoIPRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[ACLGeoIPRule], error) {
-	if domainName == "" {
-		return nil, fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Get[[]ACLGeoIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips", domainName), parameters, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ACLGeoIPRule], error) {
-		return s.GetDomainACLGeoIPRulesPaginated(domainName, p)
-	}), err
+	return s.domainACLGeoIPRuleRes().ListPaginated(domainName, parameters)
 }
 
 // GetDomainACLGeoIPRule retrieves a single ACL GeoIP rule for a domain
 func (s *Service) GetDomainACLGeoIPRule(domainName string, ruleID string) (ACLGeoIPRule, error) {
-	if domainName == "" {
-		return ACLGeoIPRule{}, fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return ACLGeoIPRule{}, fmt.Errorf("invalid rule ID")
-	}
-	body, err := connection.Get[ACLGeoIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ACLGeoIPRuleNotFoundError{ID: ruleID}))
-	return body.Data, err
+	return s.domainACLGeoIPRuleRes().Get(domainName, ruleID)
 }
 
 // CreateDomainACLGeoIPRule creates an ACL GeoIP rule
 func (s *Service) CreateDomainACLGeoIPRule(domainName string, req CreateACLGeoIPRuleRequest) (string, error) {
-	if domainName == "" {
-		return "", fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Post[ACLGeoIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
-	return body.Data.ID, err
+	rule, err := s.domainACLGeoIPRuleRes().Create(domainName, &req)
+	return rule.ID, err
 }
 
 // PatchDomainACLGeoIPRule patches an ACL GeoIP rule
 func (s *Service) PatchDomainACLGeoIPRule(domainName string, ruleID string, req PatchACLGeoIPRuleRequest) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	_, err := connection.Patch[ACLGeoIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/%s", domainName, ruleID), &req, connection.NotFoundResponseHandler(&ACLGeoIPRuleNotFoundError{ID: ruleID}))
-	return err
+	return s.domainACLGeoIPRuleRes().Patch(domainName, ruleID, &req)
 }
 
 // DeleteDomainACLGeoIPRule deletes an ACL GeoIP rule
 func (s *Service) DeleteDomainACLGeoIPRule(domainName string, ruleID string) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/geo-ips/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ACLGeoIPRuleNotFoundError{ID: ruleID}))
+	return s.domainACLGeoIPRuleRes().Delete(domainName, ruleID)
 }
 
 // GetDomainACLGeoIPRulesMode retrieves the mode for ACL GeoIP rules
@@ -430,64 +336,33 @@ func (s *Service) PatchDomainACLGeoIPRulesMode(domainName string, req PatchACLGe
 
 // GetDomainACLIPRules retrieves a list of rules
 func (s *Service) GetDomainACLIPRules(domainName string, parameters connection.APIRequestParameters) ([]ACLIPRule, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[ACLIPRule], error) {
-		return s.GetDomainACLIPRulesPaginated(domainName, p)
-	}, parameters)
+	return s.domainACLIPRuleRes().List(domainName, parameters)
 }
 
 // GetDomainACLIPRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainACLIPRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[ACLIPRule], error) {
-	if domainName == "" {
-		return nil, fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Get[[]ACLIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips", domainName), parameters, connection.NotFoundResponseHandler(&DomainWAFNotFoundError{DomainName: domainName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ACLIPRule], error) {
-		return s.GetDomainACLIPRulesPaginated(domainName, p)
-	}), err
+	return s.domainACLIPRuleRes().ListPaginated(domainName, parameters)
 }
 
 // GetDomainACLIPRule retrieves a single ACL IP rule for a domain
 func (s *Service) GetDomainACLIPRule(domainName string, ruleID string) (ACLIPRule, error) {
-	if domainName == "" {
-		return ACLIPRule{}, fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return ACLIPRule{}, fmt.Errorf("invalid rule ID")
-	}
-	body, err := connection.Get[ACLIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ACLIPRuleNotFoundError{ID: ruleID}))
-	return body.Data, err
+	return s.domainACLIPRuleRes().Get(domainName, ruleID)
 }
 
 // CreateDomainACLIPRule creates an ACL IP rule
 func (s *Service) CreateDomainACLIPRule(domainName string, req CreateACLIPRuleRequest) (string, error) {
-	if domainName == "" {
-		return "", fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Post[ACLIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips", domainName), &req, connection.NotFoundResponseHandler(&DomainNotFoundError{Name: domainName}))
-	return body.Data.ID, err
+	rule, err := s.domainACLIPRuleRes().Create(domainName, &req)
+	return rule.ID, err
 }
 
 // PatchDomainACLIPRule patches an ACL IP rule
 func (s *Service) PatchDomainACLIPRule(domainName string, ruleID string, req PatchACLIPRuleRequest) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	_, err := connection.Patch[ACLIPRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips/%s", domainName, ruleID), &req, connection.NotFoundResponseHandler(&ACLIPRuleNotFoundError{ID: ruleID}))
-	return err
+	return s.domainACLIPRuleRes().Patch(domainName, ruleID, &req)
 }
 
 // DeleteDomainACLIPRule deletes an ACL IP rule
 func (s *Service) DeleteDomainACLIPRule(domainName string, ruleID string) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/acls/ips/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ACLIPRuleNotFoundError{ID: ruleID}))
+	return s.domainACLIPRuleRes().Delete(domainName, ruleID)
 }
 
 // DownloadDomainVerificationFile downloads the verification file for a domain, returning
@@ -577,63 +452,33 @@ func (s *Service) DeleteDomainCDNConfiguration(domainName string) error {
 
 // CreateDomainCDNRule creates a CDN rule
 func (s *Service) CreateDomainCDNRule(domainName string, req CreateCDNRuleRequest) (string, error) {
-	if domainName == "" {
-		return "", fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Post[CDNRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules", domainName), &req, connection.NotFoundResponseHandler(&DomainCDNConfigurationNotFoundError{DomainName: domainName}))
-	return body.Data.ID, err
+	rule, err := s.domainCDNRuleRes().Create(domainName, &req)
+	return rule.ID, err
 }
 
 // GetDomainCDNRules retrieves a list of rules
 func (s *Service) GetDomainCDNRules(domainName string, parameters connection.APIRequestParameters) ([]CDNRule, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[CDNRule], error) {
-		return s.GetDomainCDNRulesPaginated(domainName, p)
-	}, parameters)
+	return s.domainCDNRuleRes().List(domainName, parameters)
 }
 
 // GetDomainCDNRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainCDNRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[CDNRule], error) {
-	if domainName == "" {
-		return nil, fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Get[[]CDNRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules", domainName), parameters, connection.NotFoundResponseHandler(&DomainCDNConfigurationNotFoundError{DomainName: domainName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[CDNRule], error) {
-		return s.GetDomainCDNRulesPaginated(domainName, p)
-	}), err
+	return s.domainCDNRuleRes().ListPaginated(domainName, parameters)
 }
 
 // GetDomainCDNRule retrieves a CDN rule
 func (s *Service) GetDomainCDNRule(domainName string, ruleID string) (CDNRule, error) {
-	if domainName == "" {
-		return CDNRule{}, fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return CDNRule{}, fmt.Errorf("invalid rule ID")
-	}
-	body, err := connection.Get[CDNRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CDNRuleNotFoundError{ID: ruleID}))
-	return body.Data, err
+	return s.domainCDNRuleRes().Get(domainName, ruleID)
 }
 
 // PatchDomainCDNRule patches a CDN rule
 func (s *Service) PatchDomainCDNRule(domainName string, ruleID string, req PatchCDNRuleRequest) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules/%s", domainName, ruleID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CDNRuleNotFoundError{ID: ruleID}))
+	return s.domainCDNRuleRes().Patch(domainName, ruleID, &req)
 }
 
 // DeleteDomainCDNRule removes a CDN rule
 func (s *Service) DeleteDomainCDNRule(domainName string, ruleID string) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/cdn/rules/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CDNRuleNotFoundError{ID: ruleID}))
+	return s.domainCDNRuleRes().Delete(domainName, ruleID)
 }
 
 // PurgeDomainCDN purges cached content
@@ -671,63 +516,33 @@ func (s *Service) DeleteDomainHSTSConfiguration(domainName string) error {
 
 // CreateDomainHSTSRule creates a HSTS rule
 func (s *Service) CreateDomainHSTSRule(domainName string, req CreateHSTSRuleRequest) (string, error) {
-	if domainName == "" {
-		return "", fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Post[HSTSRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules", domainName), &req, connection.NotFoundResponseHandler(&DomainHSTSConfigurationNotFoundError{DomainName: domainName}))
-	return body.Data.ID, err
+	rule, err := s.domainHSTSRuleRes().Create(domainName, &req)
+	return rule.ID, err
 }
 
 // GetDomainHSTSRules retrieves a list of rules
 func (s *Service) GetDomainHSTSRules(domainName string, parameters connection.APIRequestParameters) ([]HSTSRule, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[HSTSRule], error) {
-		return s.GetDomainHSTSRulesPaginated(domainName, p)
-	}, parameters)
+	return s.domainHSTSRuleRes().List(domainName, parameters)
 }
 
 // GetDomainHSTSRulesPaginated retrieves a paginated list of domains
 func (s *Service) GetDomainHSTSRulesPaginated(domainName string, parameters connection.APIRequestParameters) (*connection.Paginated[HSTSRule], error) {
-	if domainName == "" {
-		return nil, fmt.Errorf("invalid domain name")
-	}
-	body, err := connection.Get[[]HSTSRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules", domainName), parameters, connection.NotFoundResponseHandler(&DomainHSTSConfigurationNotFoundError{DomainName: domainName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[HSTSRule], error) {
-		return s.GetDomainHSTSRulesPaginated(domainName, p)
-	}), err
+	return s.domainHSTSRuleRes().ListPaginated(domainName, parameters)
 }
 
 // GetDomainHSTSRule retrieves a HSTS rule
 func (s *Service) GetDomainHSTSRule(domainName string, ruleID string) (HSTSRule, error) {
-	if domainName == "" {
-		return HSTSRule{}, fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return HSTSRule{}, fmt.Errorf("invalid rule ID")
-	}
-	body, err := connection.Get[HSTSRule](s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules/%s", domainName, ruleID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&HSTSRuleNotFoundError{ID: ruleID}))
-	return body.Data, err
+	return s.domainHSTSRuleRes().Get(domainName, ruleID)
 }
 
 // PatchDomainHSTSRule patches a HSTS rule
 func (s *Service) PatchDomainHSTSRule(domainName string, ruleID string, req PatchHSTSRuleRequest) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules/%s", domainName, ruleID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&HSTSRuleNotFoundError{ID: ruleID}))
+	return s.domainHSTSRuleRes().Patch(domainName, ruleID, &req)
 }
 
 // DeleteDomainHSTSRule removes a HSTS rule
 func (s *Service) DeleteDomainHSTSRule(domainName string, ruleID string) error {
-	if domainName == "" {
-		return fmt.Errorf("invalid domain name")
-	}
-	if ruleID == "" {
-		return fmt.Errorf("invalid rule ID")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/ddosx/v1/domains/%s/hsts/rules/%s", domainName, ruleID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&HSTSRuleNotFoundError{ID: ruleID}))
+	return s.domainHSTSRuleRes().Delete(domainName, ruleID)
 }
 
 // ActivateDomainDNSRouting activates DNS routing for a domain

--- a/pkg/service/draas/service_solution.go
+++ b/pkg/service/draas/service_solution.go
@@ -32,22 +32,22 @@ func (s *Service) PatchSolution(solutionID string, req PatchSolutionRequest) err
 	return s.solutionRes().Patch(solutionID, &req)
 }
 
-// GetSolutionBackupResources retrieves a collection of backup resources for specified solution
-func (s *Service) GetSolutionBackupResources(solutionID string, parameters connection.APIRequestParameters) ([]BackupResource, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[BackupResource], error) {
-		return s.GetSolutionBackupResourcesPaginated(solutionID, p)
-	}, parameters)
+func (s *Service) solutionBackupResourceRes() *resource.SubResourceList[BackupResource, string] {
+	return resource.NewStringSubResourceList[BackupResource](s.connection,
+		func(solutionID string) string {
+			return fmt.Sprintf("/draas/v1/solutions/%s/backup-resources", solutionID)
+		},
+		"solution", "id", func(solutionID string) error { return &SolutionNotFoundError{ID: solutionID} })
 }
 
-// GetSolutionsPaginated retrieves a paginated list of solutions
+// GetSolutionBackupResources retrieves a collection of backup resources for specified solution
+func (s *Service) GetSolutionBackupResources(solutionID string, parameters connection.APIRequestParameters) ([]BackupResource, error) {
+	return s.solutionBackupResourceRes().List(solutionID, parameters)
+}
+
+// GetSolutionBackupResourcesPaginated retrieves a paginated list of solution backup resources
 func (s *Service) GetSolutionBackupResourcesPaginated(solutionID string, parameters connection.APIRequestParameters) (*connection.Paginated[BackupResource], error) {
-	if solutionID == "" {
-		return nil, fmt.Errorf("invalid solution id")
-	}
-	body, err := connection.Get[[]BackupResource](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/backup-resources", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[BackupResource], error) {
-		return s.GetSolutionBackupResourcesPaginated(solutionID, p)
-	}), err
+	return s.solutionBackupResourceRes().ListPaginated(solutionID, parameters)
 }
 
 // GetSolutionBackupService retrieves the backup service for the specified solution
@@ -67,34 +67,28 @@ func (s *Service) ResetSolutionBackupServiceCredentials(solutionID string, req R
 	return connection.PostRaw(s.connection, fmt.Sprintf("/draas/v1/solutions/%s/backup-service/reset-credentials", solutionID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
 }
 
-// GetSolutionFailoverPlans retrieves a collection of failover plans for specified solution
-func (s *Service) GetSolutionFailoverPlans(solutionID string, parameters connection.APIRequestParameters) ([]FailoverPlan, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[FailoverPlan], error) {
-		return s.GetSolutionFailoverPlansPaginated(solutionID, p)
-	}, parameters)
+func (s *Service) solutionFailoverPlanRes() *resource.SubResource[FailoverPlan, string, string] {
+	return resource.NewStringStringSubResource[FailoverPlan](s.connection,
+		func(solutionID string) string {
+			return fmt.Sprintf("/draas/v1/solutions/%s/failover-plans", solutionID)
+		},
+		"solution", "id", func(solutionID string) error { return &SolutionNotFoundError{ID: solutionID} },
+		"failover plan", "id", func(_, failoverPlanID string) error { return &FailoverPlanNotFoundError{ID: failoverPlanID} })
 }
 
-// GetSolutionsPaginated retrieves a paginated list of solution failover plans
+// GetSolutionFailoverPlans retrieves a collection of failover plans for specified solution
+func (s *Service) GetSolutionFailoverPlans(solutionID string, parameters connection.APIRequestParameters) ([]FailoverPlan, error) {
+	return s.solutionFailoverPlanRes().List(solutionID, parameters)
+}
+
+// GetSolutionFailoverPlansPaginated retrieves a paginated list of solution failover plans
 func (s *Service) GetSolutionFailoverPlansPaginated(solutionID string, parameters connection.APIRequestParameters) (*connection.Paginated[FailoverPlan], error) {
-	if solutionID == "" {
-		return nil, fmt.Errorf("invalid solution id")
-	}
-	body, err := connection.Get[[]FailoverPlan](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/failover-plans", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FailoverPlan], error) {
-		return s.GetSolutionFailoverPlansPaginated(solutionID, p)
-	}), err
+	return s.solutionFailoverPlanRes().ListPaginated(solutionID, parameters)
 }
 
 // GetSolutionFailoverPlan retrieves a single solution failover plan by id
 func (s *Service) GetSolutionFailoverPlan(solutionID string, failoverPlanID string) (FailoverPlan, error) {
-	if solutionID == "" {
-		return FailoverPlan{}, fmt.Errorf("invalid solution id")
-	}
-	if failoverPlanID == "" {
-		return FailoverPlan{}, fmt.Errorf("invalid failover plan id")
-	}
-	body, err := connection.Get[FailoverPlan](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/failover-plans/%s", solutionID, failoverPlanID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&FailoverPlanNotFoundError{ID: failoverPlanID}))
-	return body.Data, err
+	return s.solutionFailoverPlanRes().Get(solutionID, failoverPlanID)
 }
 
 // StartSolutionFailoverPlan starts the specified failover plan
@@ -119,64 +113,54 @@ func (s *Service) StopSolutionFailoverPlan(solutionID string, failoverPlanID str
 	return connection.PostRaw(s.connection, fmt.Sprintf("/draas/v1/solutions/%s/failover-plans/%s/stop", solutionID, failoverPlanID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&FailoverPlanNotFoundError{ID: failoverPlanID}))
 }
 
+func (s *Service) solutionComputeResourceRes() *resource.SubResource[ComputeResource, string, string] {
+	return resource.NewStringStringSubResource[ComputeResource](s.connection,
+		func(solutionID string) string {
+			return fmt.Sprintf("/draas/v1/solutions/%s/compute-resources", solutionID)
+		},
+		"solution", "id", func(solutionID string) error { return &SolutionNotFoundError{ID: solutionID} },
+		"compute resource", "id", func(_, computeResourceID string) error {
+			return &ComputeResourceNotFoundError{ID: computeResourceID}
+		})
+}
+
 // GetSolutionComputeResources retrieves a collection of compute resources for specified solution
 func (s *Service) GetSolutionComputeResources(solutionID string, parameters connection.APIRequestParameters) ([]ComputeResource, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[ComputeResource], error) {
-		return s.GetSolutionComputeResourcesPaginated(solutionID, p)
-	}, parameters)
+	return s.solutionComputeResourceRes().List(solutionID, parameters)
 }
 
 // GetSolutionComputeResourcesPaginated retrieves a paginated list of solution compute resources
 func (s *Service) GetSolutionComputeResourcesPaginated(solutionID string, parameters connection.APIRequestParameters) (*connection.Paginated[ComputeResource], error) {
-	if solutionID == "" {
-		return nil, fmt.Errorf("invalid solution id")
-	}
-	body, err := connection.Get[[]ComputeResource](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/compute-resources", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ComputeResource], error) {
-		return s.GetSolutionComputeResourcesPaginated(solutionID, p)
-	}), err
+	return s.solutionComputeResourceRes().ListPaginated(solutionID, parameters)
 }
 
 // GetSolutionComputeResource retrieves compute resources by id
 func (s *Service) GetSolutionComputeResource(solutionID string, computeResourceID string) (ComputeResource, error) {
-	if solutionID == "" {
-		return ComputeResource{}, fmt.Errorf("invalid solution id")
-	}
-	if computeResourceID == "" {
-		return ComputeResource{}, fmt.Errorf("invalid compute resource id")
-	}
-	body, err := connection.Get[ComputeResource](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/compute-resources/%s", solutionID, computeResourceID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ComputeResourceNotFoundError{ID: computeResourceID}))
-	return body.Data, err
+	return s.solutionComputeResourceRes().Get(solutionID, computeResourceID)
+}
+
+func (s *Service) solutionHardwarePlanRes() *resource.SubResource[HardwarePlan, string, string] {
+	return resource.NewStringStringSubResource[HardwarePlan](s.connection,
+		func(solutionID string) string {
+			return fmt.Sprintf("/draas/v1/solutions/%s/hardware-plans", solutionID)
+		},
+		"solution", "id", func(solutionID string) error { return &SolutionNotFoundError{ID: solutionID} },
+		"hardware plan", "id", func(_, hardwarePlanID string) error { return &HardwarePlanNotFoundError{ID: hardwarePlanID} })
 }
 
 // GetSolutionHardwarePlans retrieves a collection of hardware plans for specified solution
 func (s *Service) GetSolutionHardwarePlans(solutionID string, parameters connection.APIRequestParameters) ([]HardwarePlan, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[HardwarePlan], error) {
-		return s.GetSolutionHardwarePlansPaginated(solutionID, p)
-	}, parameters)
+	return s.solutionHardwarePlanRes().List(solutionID, parameters)
 }
 
 // GetSolutionHardwarePlansPaginated retrieves a paginated list of solution hardware plans
 func (s *Service) GetSolutionHardwarePlansPaginated(solutionID string, parameters connection.APIRequestParameters) (*connection.Paginated[HardwarePlan], error) {
-	if solutionID == "" {
-		return nil, fmt.Errorf("invalid solution id")
-	}
-	body, err := connection.Get[[]HardwarePlan](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/hardware-plans", solutionID), parameters, connection.NotFoundResponseHandler(&SolutionNotFoundError{ID: solutionID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[HardwarePlan], error) {
-		return s.GetSolutionHardwarePlansPaginated(solutionID, p)
-	}), err
+	return s.solutionHardwarePlanRes().ListPaginated(solutionID, parameters)
 }
 
 // GetSolutionHardwarePlan retrieves hardware plans by id
 func (s *Service) GetSolutionHardwarePlan(solutionID string, hardwarePlanID string) (HardwarePlan, error) {
-	if solutionID == "" {
-		return HardwarePlan{}, fmt.Errorf("invalid solution id")
-	}
-	if hardwarePlanID == "" {
-		return HardwarePlan{}, fmt.Errorf("invalid hardware plan id")
-	}
-	body, err := connection.Get[HardwarePlan](s.connection, fmt.Sprintf("/draas/v1/solutions/%s/hardware-plans/%s", solutionID, hardwarePlanID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&HardwarePlanNotFoundError{ID: hardwarePlanID}))
-	return body.Data, err
+	return s.solutionHardwarePlanRes().Get(solutionID, hardwarePlanID)
 }
 
 // GetSolutionHardwarePlanReplicas retrieves a collection of hardware plans for specified solution

--- a/pkg/service/ecloud/service_affinityrulemember.go
+++ b/pkg/service/ecloud/service_affinityrulemember.go
@@ -13,23 +13,21 @@ func (s *Service) affinityRuleMemberRes() *resource.Resource[AffinityRuleMember,
 	})
 }
 
+func (s *Service) affinityRuleMembersRes() *resource.SubResourceList[AffinityRuleMember, string] {
+	return resource.NewUncheckedStringSubResourceList[AffinityRuleMember](s.connection,
+		func(affinityRuleID string) string {
+			return fmt.Sprintf("/ecloud/v2/affinity-rules/%s/members", affinityRuleID)
+		})
+}
+
 // GetAffinityRuleMembers retrieves a list of affinity rule members
 func (s *Service) GetAffinityRuleMembers(affinityRuleID string, parameters connection.APIRequestParameters) ([]AffinityRuleMember, error) {
-	return connection.InvokeRequestAll(
-		func(p connection.APIRequestParameters) (*connection.Paginated[AffinityRuleMember], error) {
-			return s.GetAffinityRuleMembersPaginated(affinityRuleID, p)
-		}, parameters)
+	return s.affinityRuleMembersRes().List(affinityRuleID, parameters)
 }
 
 // GetAffinityRuleMembersPaginated retrieves a paginated list of affinity rule members
 func (s *Service) GetAffinityRuleMembersPaginated(affinityRuleID string, parameters connection.APIRequestParameters) (*connection.Paginated[AffinityRuleMember], error) {
-	body, err := connection.Get[[]AffinityRuleMember](s.connection, fmt.Sprintf("/ecloud/v2/affinity-rules/%s/members", affinityRuleID), parameters)
-	return connection.NewPaginated(
-		body,
-		parameters,
-		func(p connection.APIRequestParameters) (*connection.Paginated[AffinityRuleMember], error) {
-			return s.GetAffinityRuleMembersPaginated(affinityRuleID, p)
-		}), err
+	return s.affinityRuleMembersRes().ListPaginated(affinityRuleID, parameters)
 }
 
 // GetAffinityRuleMember retrieves a single AffinityRuleMember by id

--- a/pkg/service/ecloud/service_availabilityzone.go
+++ b/pkg/service/ecloud/service_availabilityzone.go
@@ -28,20 +28,18 @@ func (s *Service) GetAvailabilityZone(azID string) (AvailabilityZone, error) {
 	return s.availabilityZoneRes().Get(azID)
 }
 
+func (s *Service) availabilityZoneIOPSTierRes() *resource.SubResourceList[IOPSTier, string] {
+	return resource.NewStringSubResourceList[IOPSTier](s.connection,
+		func(azID string) string { return fmt.Sprintf("/ecloud/v2/availability-zones/%s/iops", azID) },
+		"az", "id", func(azID string) error { return &AvailabilityZoneNotFoundError{ID: azID} })
+}
+
 // GetAvailabilityZoneIOPSTiers retrieves a list of azs
 func (s *Service) GetAvailabilityZoneIOPSTiers(azID string, parameters connection.APIRequestParameters) ([]IOPSTier, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[IOPSTier], error) {
-		return s.GetAvailabilityZoneIOPSTiersPaginated(azID, p)
-	}, parameters)
+	return s.availabilityZoneIOPSTierRes().List(azID, parameters)
 }
 
 // GetAvailabilityZoneIOPSTiersPaginated retrieves a paginated list of azs
 func (s *Service) GetAvailabilityZoneIOPSTiersPaginated(azID string, parameters connection.APIRequestParameters) (*connection.Paginated[IOPSTier], error) {
-	if azID == "" {
-		return nil, fmt.Errorf("invalid az id")
-	}
-	body, err := connection.Get[[]IOPSTier](s.connection, fmt.Sprintf("/ecloud/v2/availability-zones/%s/iops", azID), parameters, connection.NotFoundResponseHandler(&AvailabilityZoneNotFoundError{ID: azID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[IOPSTier], error) {
-		return s.GetAvailabilityZoneIOPSTiersPaginated(azID, p)
-	}), err
+	return s.availabilityZoneIOPSTierRes().ListPaginated(azID, parameters)
 }

--- a/pkg/service/ecloud/service_dhcp.go
+++ b/pkg/service/ecloud/service_dhcp.go
@@ -28,20 +28,18 @@ func (s *Service) GetDHCP(dhcpID string) (DHCP, error) {
 	return s.dhcpRes().Get(dhcpID)
 }
 
+func (s *Service) dhcpTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(dhcpID string) string { return fmt.Sprintf("/ecloud/v2/dhcps/%s/tasks", dhcpID) },
+		"dhcp", "id", func(dhcpID string) error { return &DHCPNotFoundError{ID: dhcpID} })
+}
+
 // GetDHCPTasks retrieves a list of DHCP tasks
 func (s *Service) GetDHCPTasks(dhcpID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetDHCPTasksPaginated(dhcpID, p)
-	}, parameters)
+	return s.dhcpTasksRes().List(dhcpID, parameters)
 }
 
 // GetDHCPTasksPaginated retrieves a paginated list of DHCP tasks
 func (s *Service) GetDHCPTasksPaginated(dhcpID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if dhcpID == "" {
-		return nil, fmt.Errorf("invalid dhcp id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/dhcps/%s/tasks", dhcpID), parameters, connection.NotFoundResponseHandler(&DHCPNotFoundError{ID: dhcpID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetDHCPTasksPaginated(dhcpID, p)
-	}), err
+	return s.dhcpTasksRes().ListPaginated(dhcpID, parameters)
 }

--- a/pkg/service/ecloud/service_firewallpolicy.go
+++ b/pkg/service/ecloud/service_firewallpolicy.go
@@ -52,38 +52,36 @@ func (s *Service) DeleteFirewallPolicy(policyID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) firewallPolicyRuleRes() *resource.SubResourceList[FirewallRule, string] {
+	return resource.NewStringSubResourceList[FirewallRule](s.connection,
+		func(policyID string) string {
+			return fmt.Sprintf("/ecloud/v2/firewall-policies/%s/firewall-rules", policyID)
+		},
+		"firewall policy", "id", func(policyID string) error { return &FirewallPolicyNotFoundError{ID: policyID} })
+}
+
 // GetFirewallPolicyFirewallRules retrieves a list of firewall policy rules
 func (s *Service) GetFirewallPolicyFirewallRules(policyID string, parameters connection.APIRequestParameters) ([]FirewallRule, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[FirewallRule], error) {
-		return s.GetFirewallPolicyFirewallRulesPaginated(policyID, p)
-	}, parameters)
+	return s.firewallPolicyRuleRes().List(policyID, parameters)
 }
 
 // GetFirewallPolicyFirewallRulesPaginated retrieves a paginated list of firewall policy FirewallRules
 func (s *Service) GetFirewallPolicyFirewallRulesPaginated(policyID string, parameters connection.APIRequestParameters) (*connection.Paginated[FirewallRule], error) {
-	if policyID == "" {
-		return nil, fmt.Errorf("invalid firewall policy id")
-	}
-	body, err := connection.Get[[]FirewallRule](s.connection, fmt.Sprintf("/ecloud/v2/firewall-policies/%s/firewall-rules", policyID), parameters, connection.NotFoundResponseHandler(&FirewallPolicyNotFoundError{ID: policyID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FirewallRule], error) {
-		return s.GetFirewallPolicyFirewallRulesPaginated(policyID, p)
-	}), err
+	return s.firewallPolicyRuleRes().ListPaginated(policyID, parameters)
+}
+
+func (s *Service) firewallPolicyTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(policyID string) string { return fmt.Sprintf("/ecloud/v2/firewall-policies/%s/tasks", policyID) },
+		"firewall policy", "id", func(policyID string) error { return &FirewallPolicyNotFoundError{ID: policyID} })
 }
 
 // GetFirewallPolicyTasks retrieves a list of FirewallPolicy tasks
 func (s *Service) GetFirewallPolicyTasks(policyID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetFirewallPolicyTasksPaginated(policyID, p)
-	}, parameters)
+	return s.firewallPolicyTasksRes().List(policyID, parameters)
 }
 
 // GetFirewallPolicyTasksPaginated retrieves a paginated list of FirewallPolicy tasks
 func (s *Service) GetFirewallPolicyTasksPaginated(policyID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if policyID == "" {
-		return nil, fmt.Errorf("invalid firewall policy id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/firewall-policies/%s/tasks", policyID), parameters, connection.NotFoundResponseHandler(&FirewallPolicyNotFoundError{ID: policyID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetFirewallPolicyTasksPaginated(policyID, p)
-	}), err
+	return s.firewallPolicyTasksRes().ListPaginated(policyID, parameters)
 }

--- a/pkg/service/ecloud/service_firewallrule.go
+++ b/pkg/service/ecloud/service_firewallrule.go
@@ -52,17 +52,19 @@ func (s *Service) DeleteFirewallRule(ruleID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) firewallRulePortsRes() *resource.SubResourceList[FirewallRulePort, string] {
+	return resource.NewUncheckedStringSubResourceList[FirewallRulePort](s.connection,
+		func(firewallRuleID string) string {
+			return fmt.Sprintf("/ecloud/v2/firewall-rules/%s/ports", firewallRuleID)
+		})
+}
+
 // GetFirewallRuleFirewallRulePorts retrieves a list of firewall rule ports
 func (s *Service) GetFirewallRuleFirewallRulePorts(firewallRuleID string, parameters connection.APIRequestParameters) ([]FirewallRulePort, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[FirewallRulePort], error) {
-		return s.GetFirewallRuleFirewallRulePortsPaginated(firewallRuleID, p)
-	}, parameters)
+	return s.firewallRulePortsRes().List(firewallRuleID, parameters)
 }
 
 // GetFirewallRuleFirewallRulePortsPaginated retrieves a paginated list of firewall rule ports
 func (s *Service) GetFirewallRuleFirewallRulePortsPaginated(firewallRuleID string, parameters connection.APIRequestParameters) (*connection.Paginated[FirewallRulePort], error) {
-	body, err := connection.Get[[]FirewallRulePort](s.connection, fmt.Sprintf("/ecloud/v2/firewall-rules/%s/ports", firewallRuleID), parameters)
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FirewallRulePort], error) {
-		return s.GetFirewallRuleFirewallRulePortsPaginated(firewallRuleID, p)
-	}), err
+	return s.firewallRulePortsRes().ListPaginated(firewallRuleID, parameters)
 }

--- a/pkg/service/ecloud/service_floatingip.go
+++ b/pkg/service/ecloud/service_floatingip.go
@@ -70,20 +70,18 @@ func (s *Service) UnassignFloatingIP(fipID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) floatingIPTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(fipID string) string { return fmt.Sprintf("/ecloud/v2/floating-ips/%s/tasks", fipID) },
+		"floating ip", "id", func(fipID string) error { return &FloatingIPNotFoundError{ID: fipID} })
+}
+
 // GetFloatingIPTasks retrieves a list of FloatingIP tasks
 func (s *Service) GetFloatingIPTasks(fipID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetFloatingIPTasksPaginated(fipID, p)
-	}, parameters)
+	return s.floatingIPTasksRes().List(fipID, parameters)
 }
 
 // GetFloatingIPTasksPaginated retrieves a paginated list of FloatingIP tasks
 func (s *Service) GetFloatingIPTasksPaginated(fipID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if fipID == "" {
-		return nil, fmt.Errorf("invalid floating ip id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/floating-ips/%s/tasks", fipID), parameters, connection.NotFoundResponseHandler(&FloatingIPNotFoundError{ID: fipID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetFloatingIPTasksPaginated(fipID, p)
-	}), err
+	return s.floatingIPTasksRes().ListPaginated(fipID, parameters)
 }

--- a/pkg/service/ecloud/service_host.go
+++ b/pkg/service/ecloud/service_host.go
@@ -52,20 +52,18 @@ func (s *Service) DeleteHost(hostID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) hostTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(hostID string) string { return fmt.Sprintf("/ecloud/v2/hosts/%s/tasks", hostID) },
+		"host", "id", func(hostID string) error { return &HostNotFoundError{ID: hostID} })
+}
+
 // GetHostTasks retrieves a list of Host tasks
 func (s *Service) GetHostTasks(hostID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetHostTasksPaginated(hostID, p)
-	}, parameters)
+	return s.hostTasksRes().List(hostID, parameters)
 }
 
 // GetHostTasksPaginated retrieves a paginated list of Host tasks
 func (s *Service) GetHostTasksPaginated(hostID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if hostID == "" {
-		return nil, fmt.Errorf("invalid host id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/hosts/%s/tasks", hostID), parameters, connection.NotFoundResponseHandler(&HostNotFoundError{ID: hostID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetHostTasksPaginated(hostID, p)
-	}), err
+	return s.hostTasksRes().ListPaginated(hostID, parameters)
 }

--- a/pkg/service/ecloud/service_hostgroup.go
+++ b/pkg/service/ecloud/service_hostgroup.go
@@ -52,20 +52,18 @@ func (s *Service) DeleteHostGroup(hostGroupID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) hostGroupTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(hostGroupID string) string { return fmt.Sprintf("/ecloud/v2/host-groups/%s/tasks", hostGroupID) },
+		"host group", "id", func(hostGroupID string) error { return &HostGroupNotFoundError{ID: hostGroupID} })
+}
+
 // GetHostGroupTasks retrieves a list of HostGroup tasks
 func (s *Service) GetHostGroupTasks(hostGroupID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetHostGroupTasksPaginated(hostGroupID, p)
-	}, parameters)
+	return s.hostGroupTasksRes().List(hostGroupID, parameters)
 }
 
 // GetHostGroupTasksPaginated retrieves a paginated list of HostGroup tasks
 func (s *Service) GetHostGroupTasksPaginated(hostGroupID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if hostGroupID == "" {
-		return nil, fmt.Errorf("invalid host group id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/host-groups/%s/tasks", hostGroupID), parameters, connection.NotFoundResponseHandler(&HostGroupNotFoundError{ID: hostGroupID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetHostGroupTasksPaginated(hostGroupID, p)
-	}), err
+	return s.hostGroupTasksRes().ListPaginated(hostGroupID, parameters)
 }

--- a/pkg/service/ecloud/service_image.go
+++ b/pkg/service/ecloud/service_image.go
@@ -46,38 +46,34 @@ func (s *Service) DeleteImage(imageID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) imageParameterRes() *resource.SubResourceList[ImageParameter, string] {
+	return resource.NewStringSubResourceList[ImageParameter](s.connection,
+		func(imageID string) string { return fmt.Sprintf("/ecloud/v2/images/%s/parameters", imageID) },
+		"image", "id", func(imageID string) error { return &ImageNotFoundError{ID: imageID} })
+}
+
 // GetImageParameters retrieves a list of parameters
 func (s *Service) GetImageParameters(imageID string, parameters connection.APIRequestParameters) ([]ImageParameter, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[ImageParameter], error) {
-		return s.GetImageParametersPaginated(imageID, p)
-	}, parameters)
+	return s.imageParameterRes().List(imageID, parameters)
 }
 
 // GetImageParametersPaginated retrieves a paginated list of domains
 func (s *Service) GetImageParametersPaginated(imageID string, parameters connection.APIRequestParameters) (*connection.Paginated[ImageParameter], error) {
-	if imageID == "" {
-		return nil, fmt.Errorf("invalid image id")
-	}
-	body, err := connection.Get[[]ImageParameter](s.connection, fmt.Sprintf("/ecloud/v2/images/%s/parameters", imageID), parameters, connection.NotFoundResponseHandler(&ImageNotFoundError{ID: imageID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ImageParameter], error) {
-		return s.GetImageParametersPaginated(imageID, p)
-	}), err
+	return s.imageParameterRes().ListPaginated(imageID, parameters)
+}
+
+func (s *Service) imageMetadataRes() *resource.SubResourceList[ImageMetadata, string] {
+	return resource.NewStringSubResourceList[ImageMetadata](s.connection,
+		func(imageID string) string { return fmt.Sprintf("/ecloud/v2/images/%s/metadata", imageID) },
+		"image", "id", func(imageID string) error { return &ImageNotFoundError{ID: imageID} })
 }
 
 // GetImageMetadata retrieves a list of metadata
 func (s *Service) GetImageMetadata(imageID string, parameters connection.APIRequestParameters) ([]ImageMetadata, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[ImageMetadata], error) {
-		return s.GetImageMetadataPaginated(imageID, p)
-	}, parameters)
+	return s.imageMetadataRes().List(imageID, parameters)
 }
 
 // GetImageMetadataPaginated retrieves a paginated list of domains
 func (s *Service) GetImageMetadataPaginated(imageID string, parameters connection.APIRequestParameters) (*connection.Paginated[ImageMetadata], error) {
-	if imageID == "" {
-		return nil, fmt.Errorf("invalid image id")
-	}
-	body, err := connection.Get[[]ImageMetadata](s.connection, fmt.Sprintf("/ecloud/v2/images/%s/metadata", imageID), parameters, connection.NotFoundResponseHandler(&ImageNotFoundError{ID: imageID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ImageMetadata], error) {
-		return s.GetImageMetadataPaginated(imageID, p)
-	}), err
+	return s.imageMetadataRes().ListPaginated(imageID, parameters)
 }

--- a/pkg/service/ecloud/service_instance.go
+++ b/pkg/service/ecloud/service_instance.go
@@ -114,58 +114,52 @@ func (s *Service) MigrateInstance(instanceID string, req MigrateInstanceRequest)
 	return body.Data.TaskID, err
 }
 
+func (s *Service) instanceVolumeRes() *resource.SubResourceList[Volume, string] {
+	return resource.NewStringSubResourceList[Volume](s.connection,
+		func(instanceID string) string { return fmt.Sprintf("/ecloud/v2/instances/%s/volumes", instanceID) },
+		"instance", "id", func(instanceID string) error { return &InstanceNotFoundError{ID: instanceID} })
+}
+
 // GetInstanceVolumes retrieves a list of instance volumes
 func (s *Service) GetInstanceVolumes(instanceID string, parameters connection.APIRequestParameters) ([]Volume, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-		return s.GetInstanceVolumesPaginated(instanceID, p)
-	}, parameters)
+	return s.instanceVolumeRes().List(instanceID, parameters)
 }
 
 // GetInstanceVolumesPaginated retrieves a paginated list of instance volumes
 func (s *Service) GetInstanceVolumesPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-	if instanceID == "" {
-		return nil, fmt.Errorf("invalid instance id")
-	}
-	body, err := connection.Get[[]Volume](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/volumes", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-		return s.GetInstanceVolumesPaginated(instanceID, p)
-	}), err
+	return s.instanceVolumeRes().ListPaginated(instanceID, parameters)
+}
+
+func (s *Service) instanceCredentialRes() *resource.SubResourceList[Credential, string] {
+	return resource.NewStringSubResourceList[Credential](s.connection,
+		func(instanceID string) string { return fmt.Sprintf("/ecloud/v2/instances/%s/credentials", instanceID) },
+		"instance", "id", func(instanceID string) error { return &InstanceNotFoundError{ID: instanceID} })
 }
 
 // GetInstanceCredentials retrieves a list of instance credentials
 func (s *Service) GetInstanceCredentials(instanceID string, parameters connection.APIRequestParameters) ([]Credential, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Credential], error) {
-		return s.GetInstanceCredentialsPaginated(instanceID, p)
-	}, parameters)
+	return s.instanceCredentialRes().List(instanceID, parameters)
 }
 
 // GetInstanceCredentialsPaginated retrieves a paginated list of instance credentials
 func (s *Service) GetInstanceCredentialsPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[Credential], error) {
-	if instanceID == "" {
-		return nil, fmt.Errorf("invalid instance id")
-	}
-	body, err := connection.Get[[]Credential](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/credentials", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Credential], error) {
-		return s.GetInstanceCredentialsPaginated(instanceID, p)
-	}), err
+	return s.instanceCredentialRes().ListPaginated(instanceID, parameters)
+}
+
+func (s *Service) instanceNICRes() *resource.SubResourceList[NIC, string] {
+	return resource.NewStringSubResourceList[NIC](s.connection,
+		func(instanceID string) string { return fmt.Sprintf("/ecloud/v2/instances/%s/nics", instanceID) },
+		"instance", "id", func(instanceID string) error { return &InstanceNotFoundError{ID: instanceID} })
 }
 
 // GetInstanceNICs retrieves a list of instance NICs
 func (s *Service) GetInstanceNICs(instanceID string, parameters connection.APIRequestParameters) ([]NIC, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
-		return s.GetInstanceNICsPaginated(instanceID, p)
-	}, parameters)
+	return s.instanceNICRes().List(instanceID, parameters)
 }
 
 // GetInstanceNICsPaginated retrieves a paginated list of instance NICs
 func (s *Service) GetInstanceNICsPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
-	if instanceID == "" {
-		return nil, fmt.Errorf("invalid instance id")
-	}
-	body, err := connection.Get[[]NIC](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/nics", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
-		return s.GetInstanceNICsPaginated(instanceID, p)
-	}), err
+	return s.instanceNICRes().ListPaginated(instanceID, parameters)
 }
 
 // CreateInstanceConsoleSession creates an instance console session
@@ -177,22 +171,20 @@ func (s *Service) CreateInstanceConsoleSession(instanceID string) (ConsoleSessio
 	return body.Data, err
 }
 
+func (s *Service) instanceTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(instanceID string) string { return fmt.Sprintf("/ecloud/v2/instances/%s/tasks", instanceID) },
+		"instance", "id", func(instanceID string) error { return &InstanceNotFoundError{ID: instanceID} })
+}
+
 // GetInstanceTasks retrieves a list of Instance tasks
 func (s *Service) GetInstanceTasks(instanceID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetInstanceTasksPaginated(instanceID, p)
-	}, parameters)
+	return s.instanceTasksRes().List(instanceID, parameters)
 }
 
 // GetInstanceTasksPaginated retrieves a paginated list of Instance tasks
 func (s *Service) GetInstanceTasksPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if instanceID == "" {
-		return nil, fmt.Errorf("invalid instance id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/tasks", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetInstanceTasksPaginated(instanceID, p)
-	}), err
+	return s.instanceTasksRes().ListPaginated(instanceID, parameters)
 }
 
 // AttachInstanceVolume attaches a volume to an instance
@@ -213,22 +205,20 @@ func (s *Service) DetachInstanceVolume(instanceID string, req AttachDetachInstan
 	return body.Data.TaskID, err
 }
 
+func (s *Service) instanceFloatingIPRes() *resource.SubResourceList[FloatingIP, string] {
+	return resource.NewStringSubResourceList[FloatingIP](s.connection,
+		func(instanceID string) string { return fmt.Sprintf("/ecloud/v2/instances/%s/floating-ips", instanceID) },
+		"instance", "id", func(instanceID string) error { return &InstanceNotFoundError{ID: instanceID} })
+}
+
 // GetInstanceFloatingIPs retrieves a list of instance fips
 func (s *Service) GetInstanceFloatingIPs(instanceID string, parameters connection.APIRequestParameters) ([]FloatingIP, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[FloatingIP], error) {
-		return s.GetInstanceFloatingIPsPaginated(instanceID, p)
-	}, parameters)
+	return s.instanceFloatingIPRes().List(instanceID, parameters)
 }
 
 // GetInstanceFloatingIPsPaginated retrieves a paginated list of instance floating IPs
 func (s *Service) GetInstanceFloatingIPsPaginated(instanceID string, parameters connection.APIRequestParameters) (*connection.Paginated[FloatingIP], error) {
-	if instanceID == "" {
-		return nil, fmt.Errorf("invalid instance id")
-	}
-	body, err := connection.Get[[]FloatingIP](s.connection, fmt.Sprintf("/ecloud/v2/instances/%s/floating-ips", instanceID), parameters, connection.NotFoundResponseHandler(&InstanceNotFoundError{ID: instanceID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FloatingIP], error) {
-		return s.GetInstanceFloatingIPsPaginated(instanceID, p)
-	}), err
+	return s.instanceFloatingIPRes().ListPaginated(instanceID, parameters)
 }
 
 // CreateInstanceImage attaches a volume to an instance

--- a/pkg/service/ecloud/service_network.go
+++ b/pkg/service/ecloud/service_network.go
@@ -44,35 +44,33 @@ func (s *Service) DeleteNetwork(networkID string) error {
 	return s.networkRes().Delete(networkID)
 }
 
+func (s *Service) networkNICRes() *resource.SubResourceList[NIC, string] {
+	return resource.NewUncheckedStringSubResourceList[NIC](s.connection,
+		func(networkID string) string { return fmt.Sprintf("/ecloud/v2/networks/%s/nics", networkID) })
+}
+
 // GetNetworkNICs retrieves a list of firewall rule nics
 func (s *Service) GetNetworkNICs(networkID string, parameters connection.APIRequestParameters) ([]NIC, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
-		return s.GetNetworkNICsPaginated(networkID, p)
-	}, parameters)
+	return s.networkNICRes().List(networkID, parameters)
 }
 
 // GetNetworkNICsPaginated retrieves a paginated list of firewall rule nics
 func (s *Service) GetNetworkNICsPaginated(networkID string, parameters connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
-	body, err := connection.Get[[]NIC](s.connection, fmt.Sprintf("/ecloud/v2/networks/%s/nics", networkID), parameters)
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[NIC], error) {
-		return s.GetNetworkNICsPaginated(networkID, p)
-	}), err
+	return s.networkNICRes().ListPaginated(networkID, parameters)
+}
+
+func (s *Service) networkTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(networkID string) string { return fmt.Sprintf("/ecloud/v2/networks/%s/tasks", networkID) },
+		"network", "id", func(networkID string) error { return &NetworkNotFoundError{ID: networkID} })
 }
 
 // GetNetworkTasks retrieves a list of Network tasks
 func (s *Service) GetNetworkTasks(networkID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetNetworkTasksPaginated(networkID, p)
-	}, parameters)
+	return s.networkTasksRes().List(networkID, parameters)
 }
 
 // GetNetworkTasksPaginated retrieves a paginated list of Network tasks
 func (s *Service) GetNetworkTasksPaginated(networkID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if networkID == "" {
-		return nil, fmt.Errorf("invalid network id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/networks/%s/tasks", networkID), parameters, connection.NotFoundResponseHandler(&NetworkNotFoundError{ID: networkID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetNetworkTasksPaginated(networkID, p)
-	}), err
+	return s.networkTasksRes().ListPaginated(networkID, parameters)
 }

--- a/pkg/service/ecloud/service_networkpolicy.go
+++ b/pkg/service/ecloud/service_networkpolicy.go
@@ -52,38 +52,36 @@ func (s *Service) DeleteNetworkPolicy(policyID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) networkPolicyRuleRes() *resource.SubResourceList[NetworkRule, string] {
+	return resource.NewStringSubResourceList[NetworkRule](s.connection,
+		func(policyID string) string {
+			return fmt.Sprintf("/ecloud/v2/network-policies/%s/network-rules", policyID)
+		},
+		"network policy", "id", func(policyID string) error { return &NetworkPolicyNotFoundError{ID: policyID} })
+}
+
 // GetNetworkPolicyNetworkRules retrieves a list of network policy rules
 func (s *Service) GetNetworkPolicyNetworkRules(policyID string, parameters connection.APIRequestParameters) ([]NetworkRule, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[NetworkRule], error) {
-		return s.GetNetworkPolicyNetworkRulesPaginated(policyID, p)
-	}, parameters)
+	return s.networkPolicyRuleRes().List(policyID, parameters)
 }
 
 // GetNetworkPolicyNetworkRulesPaginated retrieves a paginated list of network policy NetworkRules
 func (s *Service) GetNetworkPolicyNetworkRulesPaginated(policyID string, parameters connection.APIRequestParameters) (*connection.Paginated[NetworkRule], error) {
-	if policyID == "" {
-		return nil, fmt.Errorf("invalid network policy id")
-	}
-	body, err := connection.Get[[]NetworkRule](s.connection, fmt.Sprintf("/ecloud/v2/network-policies/%s/network-rules", policyID), parameters, connection.NotFoundResponseHandler(&NetworkPolicyNotFoundError{ID: policyID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[NetworkRule], error) {
-		return s.GetNetworkPolicyNetworkRulesPaginated(policyID, p)
-	}), err
+	return s.networkPolicyRuleRes().ListPaginated(policyID, parameters)
+}
+
+func (s *Service) networkPolicyTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(policyID string) string { return fmt.Sprintf("/ecloud/v2/network-policies/%s/tasks", policyID) },
+		"network policy", "id", func(policyID string) error { return &NetworkPolicyNotFoundError{ID: policyID} })
 }
 
 // GetNetworkPolicyTasks retrieves a list of NetworkPolicy tasks
 func (s *Service) GetNetworkPolicyTasks(policyID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetNetworkPolicyTasksPaginated(policyID, p)
-	}, parameters)
+	return s.networkPolicyTasksRes().List(policyID, parameters)
 }
 
 // GetNetworkPolicyTasksPaginated retrieves a paginated list of NetworkPolicy tasks
 func (s *Service) GetNetworkPolicyTasksPaginated(policyID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if policyID == "" {
-		return nil, fmt.Errorf("invalid network policy id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/network-policies/%s/tasks", policyID), parameters, connection.NotFoundResponseHandler(&NetworkPolicyNotFoundError{ID: policyID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetNetworkPolicyTasksPaginated(policyID, p)
-	}), err
+	return s.networkPolicyTasksRes().ListPaginated(policyID, parameters)
 }

--- a/pkg/service/ecloud/service_networkrule.go
+++ b/pkg/service/ecloud/service_networkrule.go
@@ -52,17 +52,19 @@ func (s *Service) DeleteNetworkRule(ruleID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) networkRulePortsRes() *resource.SubResourceList[NetworkRulePort, string] {
+	return resource.NewUncheckedStringSubResourceList[NetworkRulePort](s.connection,
+		func(networkRuleID string) string {
+			return fmt.Sprintf("/ecloud/v2/network-rules/%s/ports", networkRuleID)
+		})
+}
+
 // GetNetworkRuleNetworkRulePorts retrieves a list of network rule ports
 func (s *Service) GetNetworkRuleNetworkRulePorts(networkRuleID string, parameters connection.APIRequestParameters) ([]NetworkRulePort, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[NetworkRulePort], error) {
-		return s.GetNetworkRuleNetworkRulePortsPaginated(networkRuleID, p)
-	}, parameters)
+	return s.networkRulePortsRes().List(networkRuleID, parameters)
 }
 
 // GetNetworkRuleNetworkRulePortsPaginated retrieves a paginated list of network rule ports
 func (s *Service) GetNetworkRuleNetworkRulePortsPaginated(networkRuleID string, parameters connection.APIRequestParameters) (*connection.Paginated[NetworkRulePort], error) {
-	body, err := connection.Get[[]NetworkRulePort](s.connection, fmt.Sprintf("/ecloud/v2/network-rules/%s/ports", networkRuleID), parameters)
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[NetworkRulePort], error) {
-		return s.GetNetworkRuleNetworkRulePortsPaginated(networkRuleID, p)
-	}), err
+	return s.networkRulePortsRes().ListPaginated(networkRuleID, parameters)
 }

--- a/pkg/service/ecloud/service_nic.go
+++ b/pkg/service/ecloud/service_nic.go
@@ -28,40 +28,36 @@ func (s *Service) GetNIC(nicID string) (NIC, error) {
 	return s.nicRes().Get(nicID)
 }
 
+func (s *Service) nicTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(nicID string) string { return fmt.Sprintf("/ecloud/v2/nics/%s/tasks", nicID) },
+		"nic", "id", func(nicID string) error { return &NICNotFoundError{ID: nicID} })
+}
+
 // GetNICTasks retrieves a list of NIC tasks
 func (s *Service) GetNICTasks(nicID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetNICTasksPaginated(nicID, p)
-	}, parameters)
+	return s.nicTasksRes().List(nicID, parameters)
 }
 
 // GetNICTasksPaginated retrieves a paginated list of NIC tasks
 func (s *Service) GetNICTasksPaginated(nicID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if nicID == "" {
-		return nil, fmt.Errorf("invalid nic id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/nics/%s/tasks", nicID), parameters, connection.NotFoundResponseHandler(&NICNotFoundError{ID: nicID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetNICTasksPaginated(nicID, p)
-	}), err
+	return s.nicTasksRes().ListPaginated(nicID, parameters)
+}
+
+func (s *Service) nicIPAddressRes() *resource.SubResourceList[IPAddress, string] {
+	return resource.NewStringSubResourceList[IPAddress](s.connection,
+		func(nicID string) string { return fmt.Sprintf("/ecloud/v2/nics/%s/ip-addresses", nicID) },
+		"nic", "id", func(nicID string) error { return &NICNotFoundError{ID: nicID} })
 }
 
 // GetNICIPAddress retrieves a list of NIC IP addresses
 func (s *Service) GetNICIPAddresses(nicID string, parameters connection.APIRequestParameters) ([]IPAddress, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[IPAddress], error) {
-		return s.GetNICIPAddressesPaginated(nicID, p)
-	}, parameters)
+	return s.nicIPAddressRes().List(nicID, parameters)
 }
 
 // GetNICIPAddressPaginated retrieves a paginated list of NIC IP addresses
 func (s *Service) GetNICIPAddressesPaginated(nicID string, parameters connection.APIRequestParameters) (*connection.Paginated[IPAddress], error) {
-	if nicID == "" {
-		return nil, fmt.Errorf("invalid nic id")
-	}
-	body, err := connection.Get[[]IPAddress](s.connection, fmt.Sprintf("/ecloud/v2/nics/%s/ip-addresses", nicID), parameters, connection.NotFoundResponseHandler(&NICNotFoundError{ID: nicID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[IPAddress], error) {
-		return s.GetNICIPAddressesPaginated(nicID, p)
-	}), err
+	return s.nicIPAddressRes().ListPaginated(nicID, parameters)
 }
 
 func (s *Service) AssignNICIPAddress(nicID string, req AssignIPAddressRequest) (string, error) {

--- a/pkg/service/ecloud/service_router.go
+++ b/pkg/service/ecloud/service_router.go
@@ -44,58 +44,52 @@ func (s *Service) DeleteRouter(routerID string) error {
 	return s.routerRes().Delete(routerID)
 }
 
+func (s *Service) routerFirewallPolicyRes() *resource.SubResourceList[FirewallPolicy, string] {
+	return resource.NewStringSubResourceList[FirewallPolicy](s.connection,
+		func(routerID string) string { return fmt.Sprintf("/ecloud/v2/routers/%s/firewall-policies", routerID) },
+		"router", "id", func(routerID string) error { return &RouterNotFoundError{ID: routerID} })
+}
+
 // GetRouterFirewallPolicies retrieves a list of firewall rule policies
 func (s *Service) GetRouterFirewallPolicies(routerID string, parameters connection.APIRequestParameters) ([]FirewallPolicy, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[FirewallPolicy], error) {
-		return s.GetRouterFirewallPoliciesPaginated(routerID, p)
-	}, parameters)
+	return s.routerFirewallPolicyRes().List(routerID, parameters)
 }
 
 // GetRouterFirewallPoliciesPaginated retrieves a paginated list of firewall rule policies
 func (s *Service) GetRouterFirewallPoliciesPaginated(routerID string, parameters connection.APIRequestParameters) (*connection.Paginated[FirewallPolicy], error) {
-	if routerID == "" {
-		return nil, fmt.Errorf("invalid router id")
-	}
-	body, err := connection.Get[[]FirewallPolicy](s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/firewall-policies", routerID), parameters, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[FirewallPolicy], error) {
-		return s.GetRouterFirewallPoliciesPaginated(routerID, p)
-	}), err
+	return s.routerFirewallPolicyRes().ListPaginated(routerID, parameters)
+}
+
+func (s *Service) routerNetworkRes() *resource.SubResourceList[Network, string] {
+	return resource.NewStringSubResourceList[Network](s.connection,
+		func(routerID string) string { return fmt.Sprintf("/ecloud/v2/routers/%s/networks", routerID) },
+		"router", "id", func(routerID string) error { return &RouterNotFoundError{ID: routerID} })
 }
 
 // GetRouterNetworks retrieves a list of router networks
 func (s *Service) GetRouterNetworks(routerID string, parameters connection.APIRequestParameters) ([]Network, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Network], error) {
-		return s.GetRouterNetworksPaginated(routerID, p)
-	}, parameters)
+	return s.routerNetworkRes().List(routerID, parameters)
 }
 
 // GetRouterNetworksPaginated retrieves a paginated list of router networks
 func (s *Service) GetRouterNetworksPaginated(routerID string, parameters connection.APIRequestParameters) (*connection.Paginated[Network], error) {
-	if routerID == "" {
-		return nil, fmt.Errorf("invalid router id")
-	}
-	body, err := connection.Get[[]Network](s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/networks", routerID), parameters, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Network], error) {
-		return s.GetRouterNetworksPaginated(routerID, p)
-	}), err
+	return s.routerNetworkRes().ListPaginated(routerID, parameters)
+}
+
+func (s *Service) routerVPNRes() *resource.SubResourceList[VPN, string] {
+	return resource.NewStringSubResourceList[VPN](s.connection,
+		func(routerID string) string { return fmt.Sprintf("/ecloud/v2/routers/%s/vpns", routerID) },
+		"router", "id", func(routerID string) error { return &RouterNotFoundError{ID: routerID} })
 }
 
 // GetRouterVPNs retrieves a list of router VPNs
 func (s *Service) GetRouterVPNs(routerID string, parameters connection.APIRequestParameters) ([]VPN, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[VPN], error) {
-		return s.GetRouterVPNsPaginated(routerID, p)
-	}, parameters)
+	return s.routerVPNRes().List(routerID, parameters)
 }
 
 // GetRouterVPNsPaginated retrieves a paginated list of router VPNs
 func (s *Service) GetRouterVPNsPaginated(routerID string, parameters connection.APIRequestParameters) (*connection.Paginated[VPN], error) {
-	if routerID == "" {
-		return nil, fmt.Errorf("invalid router id")
-	}
-	body, err := connection.Get[[]VPN](s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/vpns", routerID), parameters, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[VPN], error) {
-		return s.GetRouterVPNsPaginated(routerID, p)
-	}), err
+	return s.routerVPNRes().ListPaginated(routerID, parameters)
 }
 
 // DeployRouterDefaultFirewallPolicies deploys default firewall policy resources for specified router
@@ -106,20 +100,18 @@ func (s *Service) DeployRouterDefaultFirewallPolicies(routerID string) error {
 	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/configure-default-policies", routerID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
 }
 
+func (s *Service) routerTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(routerID string) string { return fmt.Sprintf("/ecloud/v2/routers/%s/tasks", routerID) },
+		"router", "id", func(routerID string) error { return &RouterNotFoundError{ID: routerID} })
+}
+
 // GetRouterTasks retrieves a list of Router tasks
 func (s *Service) GetRouterTasks(routerID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetRouterTasksPaginated(routerID, p)
-	}, parameters)
+	return s.routerTasksRes().List(routerID, parameters)
 }
 
 // GetRouterTasksPaginated retrieves a paginated list of Router tasks
 func (s *Service) GetRouterTasksPaginated(routerID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if routerID == "" {
-		return nil, fmt.Errorf("invalid router id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/routers/%s/tasks", routerID), parameters, connection.NotFoundResponseHandler(&RouterNotFoundError{ID: routerID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetRouterTasksPaginated(routerID, p)
-	}), err
+	return s.routerTasksRes().ListPaginated(routerID, parameters)
 }

--- a/pkg/service/ecloud/service_volume.go
+++ b/pkg/service/ecloud/service_volume.go
@@ -52,38 +52,34 @@ func (s *Service) DeleteVolume(volumeID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) volumeInstanceRes() *resource.SubResourceList[Instance, string] {
+	return resource.NewStringSubResourceList[Instance](s.connection,
+		func(volumeID string) string { return fmt.Sprintf("/ecloud/v2/volumes/%s/instances", volumeID) },
+		"volume", "id", func(volumeID string) error { return &VolumeNotFoundError{ID: volumeID} })
+}
+
 // GetVolumeInstances retrieves a list of volume instances
 func (s *Service) GetVolumeInstances(volumeID string, parameters connection.APIRequestParameters) ([]Instance, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
-		return s.GetVolumeInstancesPaginated(volumeID, p)
-	}, parameters)
+	return s.volumeInstanceRes().List(volumeID, parameters)
 }
 
 // GetVolumeInstancesPaginated retrieves a paginated list of volume instances
 func (s *Service) GetVolumeInstancesPaginated(volumeID string, parameters connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
-	if volumeID == "" {
-		return nil, fmt.Errorf("invalid volume id")
-	}
-	body, err := connection.Get[[]Instance](s.connection, fmt.Sprintf("/ecloud/v2/volumes/%s/instances", volumeID), parameters, connection.NotFoundResponseHandler(&VolumeNotFoundError{ID: volumeID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
-		return s.GetVolumeInstancesPaginated(volumeID, p)
-	}), err
+	return s.volumeInstanceRes().ListPaginated(volumeID, parameters)
+}
+
+func (s *Service) volumeTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(volumeID string) string { return fmt.Sprintf("/ecloud/v2/volumes/%s/tasks", volumeID) },
+		"volume", "id", func(volumeID string) error { return &VolumeNotFoundError{ID: volumeID} })
 }
 
 // GetVolumeTasks retrieves a list of Volume tasks
 func (s *Service) GetVolumeTasks(volumeID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVolumeTasksPaginated(volumeID, p)
-	}, parameters)
+	return s.volumeTasksRes().List(volumeID, parameters)
 }
 
 // GetVolumeTasksPaginated retrieves a paginated list of Volume tasks
 func (s *Service) GetVolumeTasksPaginated(volumeID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if volumeID == "" {
-		return nil, fmt.Errorf("invalid volume id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/volumes/%s/tasks", volumeID), parameters, connection.NotFoundResponseHandler(&VolumeNotFoundError{ID: volumeID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVolumeTasksPaginated(volumeID, p)
-	}), err
+	return s.volumeTasksRes().ListPaginated(volumeID, parameters)
 }

--- a/pkg/service/ecloud/service_volumegroup.go
+++ b/pkg/service/ecloud/service_volumegroup.go
@@ -52,20 +52,20 @@ func (s *Service) DeleteVolumeGroup(volumeGroupID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) volumeGroupVolumeRes() *resource.SubResourceList[Volume, string] {
+	return resource.NewStringSubResourceList[Volume](s.connection,
+		func(volumeGroupID string) string {
+			return fmt.Sprintf("/ecloud/v2/volume-groups/%s/volumes", volumeGroupID)
+		},
+		"volume group", "id", func(volumeGroupID string) error { return &VolumeGroupNotFoundError{ID: volumeGroupID} })
+}
+
 // GetVolumeGroupVolumes retrieves a list of VolumeGroup volumes
 func (s *Service) GetVolumeGroupVolumes(volumeGroupID string, parameters connection.APIRequestParameters) ([]Volume, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-		return s.GetVolumeGroupVolumesPaginated(volumeGroupID, p)
-	}, parameters)
+	return s.volumeGroupVolumeRes().List(volumeGroupID, parameters)
 }
 
 // GetVolumeGroupVolumesPaginated retrieves a paginated list of VolumeGroup volumes
 func (s *Service) GetVolumeGroupVolumesPaginated(volumeGroupID string, parameters connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-	if volumeGroupID == "" {
-		return nil, fmt.Errorf("invalid volume group id")
-	}
-	body, err := connection.Get[[]Volume](s.connection, fmt.Sprintf("/ecloud/v2/volume-groups/%s/volumes", volumeGroupID), parameters, connection.NotFoundResponseHandler(&VolumeGroupNotFoundError{ID: volumeGroupID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-		return s.GetVolumeGroupVolumesPaginated(volumeGroupID, p)
-	}), err
+	return s.volumeGroupVolumeRes().ListPaginated(volumeGroupID, parameters)
 }

--- a/pkg/service/ecloud/service_vpc.go
+++ b/pkg/service/ecloud/service_vpc.go
@@ -52,56 +52,50 @@ func (s *Service) DeployVPCDefaults(vpcID string) error {
 	return connection.PostRaw(s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s/deploy-defaults", vpcID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
 }
 
+func (s *Service) vpcVolumeRes() *resource.SubResourceList[Volume, string] {
+	return resource.NewStringSubResourceList[Volume](s.connection,
+		func(vpcID string) string { return fmt.Sprintf("/ecloud/v2/vpcs/%s/volumes", vpcID) },
+		"vpc", "id", func(vpcID string) error { return &VPCNotFoundError{ID: vpcID} })
+}
+
 // GetVPCVolumes retrieves a list of firewall rule volumes
 func (s *Service) GetVPCVolumes(vpcID string, parameters connection.APIRequestParameters) ([]Volume, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-		return s.GetVPCVolumesPaginated(vpcID, p)
-	}, parameters)
+	return s.vpcVolumeRes().List(vpcID, parameters)
 }
 
 // GetVPCVolumesPaginated retrieves a paginated list of firewall rule volumes
 func (s *Service) GetVPCVolumesPaginated(vpcID string, parameters connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-	if vpcID == "" {
-		return nil, fmt.Errorf("invalid vpc id")
-	}
-	body, err := connection.Get[[]Volume](s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s/volumes", vpcID), parameters, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Volume], error) {
-		return s.GetVPCVolumesPaginated(vpcID, p)
-	}), err
+	return s.vpcVolumeRes().ListPaginated(vpcID, parameters)
+}
+
+func (s *Service) vpcInstanceRes() *resource.SubResourceList[Instance, string] {
+	return resource.NewStringSubResourceList[Instance](s.connection,
+		func(vpcID string) string { return fmt.Sprintf("/ecloud/v2/vpcs/%s/instances", vpcID) },
+		"vpc", "id", func(vpcID string) error { return &VPCNotFoundError{ID: vpcID} })
 }
 
 // GetVPCInstances retrieves a list of firewall rule instances
 func (s *Service) GetVPCInstances(vpcID string, parameters connection.APIRequestParameters) ([]Instance, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
-		return s.GetVPCInstancesPaginated(vpcID, p)
-	}, parameters)
+	return s.vpcInstanceRes().List(vpcID, parameters)
 }
 
 // GetVPCInstancesPaginated retrieves a paginated list of firewall rule instances
 func (s *Service) GetVPCInstancesPaginated(vpcID string, parameters connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
-	if vpcID == "" {
-		return nil, fmt.Errorf("invalid vpc id")
-	}
-	body, err := connection.Get[[]Instance](s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s/instances", vpcID), parameters, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Instance], error) {
-		return s.GetVPCInstancesPaginated(vpcID, p)
-	}), err
+	return s.vpcInstanceRes().ListPaginated(vpcID, parameters)
+}
+
+func (s *Service) vpcTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(vpcID string) string { return fmt.Sprintf("/ecloud/v2/vpcs/%s/tasks", vpcID) },
+		"vpc", "id", func(vpcID string) error { return &VPCNotFoundError{ID: vpcID} })
 }
 
 // GetVPCTasks retrieves a list of VPC tasks
 func (s *Service) GetVPCTasks(vpcID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPCTasksPaginated(vpcID, p)
-	}, parameters)
+	return s.vpcTasksRes().List(vpcID, parameters)
 }
 
 // GetVPCTasksPaginated retrieves a paginated list of VPC tasks
 func (s *Service) GetVPCTasksPaginated(vpcID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if vpcID == "" {
-		return nil, fmt.Errorf("invalid vpc id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpcs/%s/tasks", vpcID), parameters, connection.NotFoundResponseHandler(&VPCNotFoundError{ID: vpcID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPCTasksPaginated(vpcID, p)
-	}), err
+	return s.vpcTasksRes().ListPaginated(vpcID, parameters)
 }

--- a/pkg/service/ecloud/service_vpnendpoint.go
+++ b/pkg/service/ecloud/service_vpnendpoint.go
@@ -52,20 +52,18 @@ func (s *Service) DeleteVPNEndpoint(endpointID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) vpnEndpointTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(endpointID string) string { return fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s/tasks", endpointID) },
+		"vpn endpoint", "id", func(endpointID string) error { return &VPNEndpointNotFoundError{ID: endpointID} })
+}
+
 // GetVPNEndpointTasks retrieves a list of VPN endpoint tasks
 func (s *Service) GetVPNEndpointTasks(endpointID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPNEndpointTasksPaginated(endpointID, p)
-	}, parameters)
+	return s.vpnEndpointTasksRes().List(endpointID, parameters)
 }
 
 // GetVPNEndpointTasksPaginated retrieves a paginated list of VPN endpoint tasks
 func (s *Service) GetVPNEndpointTasksPaginated(endpointID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if endpointID == "" {
-		return nil, fmt.Errorf("invalid vpn endpoint id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpn-endpoints/%s/tasks", endpointID), parameters, connection.NotFoundResponseHandler(&VPNEndpointNotFoundError{ID: endpointID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPNEndpointTasksPaginated(endpointID, p)
-	}), err
+	return s.vpnEndpointTasksRes().ListPaginated(endpointID, parameters)
 }

--- a/pkg/service/ecloud/service_vpngateway.go
+++ b/pkg/service/ecloud/service_vpngateway.go
@@ -52,20 +52,18 @@ func (s *Service) DeleteVPNGateway(gatewayID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) vpnGatewayTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(gatewayID string) string { return fmt.Sprintf("/ecloud/v2/vpn-gateways/%s/tasks", gatewayID) },
+		"vpn gateway", "id", func(gatewayID string) error { return &VPNGatewayNotFoundError{ID: gatewayID} })
+}
+
 // GetVPNGatewayTasks retrieves a list of VPN gateway tasks
 func (s *Service) GetVPNGatewayTasks(gatewayID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPNGatewayTasksPaginated(gatewayID, p)
-	}, parameters)
+	return s.vpnGatewayTasksRes().List(gatewayID, parameters)
 }
 
 // GetVPNGatewayTasksPaginated retrieves a paginated list of VPN gateway tasks
 func (s *Service) GetVPNGatewayTasksPaginated(gatewayID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if gatewayID == "" {
-		return nil, fmt.Errorf("invalid vpn gateway id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateways/%s/tasks", gatewayID), parameters, connection.NotFoundResponseHandler(&VPNGatewayNotFoundError{ID: gatewayID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPNGatewayTasksPaginated(gatewayID, p)
-	}), err
+	return s.vpnGatewayTasksRes().ListPaginated(gatewayID, parameters)
 }

--- a/pkg/service/ecloud/service_vpngatewayspecs.go
+++ b/pkg/service/ecloud/service_vpngatewayspecs.go
@@ -28,20 +28,22 @@ func (s *Service) GetVPNGatewaySpecification(specificationID string) (VPNGateway
 	return s.vpnGatewaySpecificationRes().Get(specificationID)
 }
 
+func (s *Service) vpnGatewaySpecAvailabilityZoneRes() *resource.SubResourceList[AvailabilityZone, string] {
+	return resource.NewStringSubResourceList[AvailabilityZone](s.connection,
+		func(specificationID string) string {
+			return fmt.Sprintf("/ecloud/v2/vpn-gateway-specifications/%s/availability-zones", specificationID)
+		},
+		"vpn gateway specification", "id", func(specificationID string) error {
+			return &VPNGatewaySpecificationNotFoundError{ID: specificationID}
+		})
+}
+
 // GetVPNGatewaySpecificationAvailabilityZones retrieves a list of availability zones for a vpn gateway specification
 func (s *Service) GetVPNGatewaySpecificationAvailabilityZones(specificationID string, parameters connection.APIRequestParameters) ([]AvailabilityZone, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[AvailabilityZone], error) {
-		return s.GetVPNGatewaySpecificationAvailabilityZonesPaginated(specificationID, p)
-	}, parameters)
+	return s.vpnGatewaySpecAvailabilityZoneRes().List(specificationID, parameters)
 }
 
 // GetVPNGatewaySpecificationAvailabilityZonesPaginated retrieves a paginated list of availability zones for a vpn gateway specification
 func (s *Service) GetVPNGatewaySpecificationAvailabilityZonesPaginated(specificationID string, parameters connection.APIRequestParameters) (*connection.Paginated[AvailabilityZone], error) {
-	if specificationID == "" {
-		return nil, fmt.Errorf("invalid vpn gateway specification id")
-	}
-	body, err := connection.Get[[]AvailabilityZone](s.connection, fmt.Sprintf("/ecloud/v2/vpn-gateway-specifications/%s/availability-zones", specificationID), parameters, connection.NotFoundResponseHandler(&VPNGatewaySpecificationNotFoundError{ID: specificationID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[AvailabilityZone], error) {
-		return s.GetVPNGatewaySpecificationAvailabilityZonesPaginated(specificationID, p)
-	}), err
+	return s.vpnGatewaySpecAvailabilityZoneRes().ListPaginated(specificationID, parameters)
 }

--- a/pkg/service/ecloud/service_vpnservice.go
+++ b/pkg/service/ecloud/service_vpnservice.go
@@ -52,20 +52,18 @@ func (s *Service) DeleteVPNService(serviceID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) vpnServiceTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(serviceID string) string { return fmt.Sprintf("/ecloud/v2/vpn-services/%s/tasks", serviceID) },
+		"vpn service", "id", func(serviceID string) error { return &VPNServiceNotFoundError{ID: serviceID} })
+}
+
 // GetVPNServiceTasks retrieves a list of VPN service tasks
 func (s *Service) GetVPNServiceTasks(serviceID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPNServiceTasksPaginated(serviceID, p)
-	}, parameters)
+	return s.vpnServiceTasksRes().List(serviceID, parameters)
 }
 
 // GetVPNServiceTasksPaginated retrieves a paginated list of VPN service tasks
 func (s *Service) GetVPNServiceTasksPaginated(serviceID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if serviceID == "" {
-		return nil, fmt.Errorf("invalid vpn service id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpn-services/%s/tasks", serviceID), parameters, connection.NotFoundResponseHandler(&VPNServiceNotFoundError{ID: serviceID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPNServiceTasksPaginated(serviceID, p)
-	}), err
+	return s.vpnServiceTasksRes().ListPaginated(serviceID, parameters)
 }

--- a/pkg/service/ecloud/service_vpnsession.go
+++ b/pkg/service/ecloud/service_vpnsession.go
@@ -52,22 +52,20 @@ func (s *Service) DeleteVPNSession(sessionID string) (string, error) {
 	return body.Data.TaskID, err
 }
 
+func (s *Service) vpnSessionTasksRes() *resource.SubResourceList[Task, string] {
+	return resource.NewStringSubResourceList[Task](s.connection,
+		func(sessionID string) string { return fmt.Sprintf("/ecloud/v2/vpn-sessions/%s/tasks", sessionID) },
+		"vpn session", "id", func(sessionID string) error { return &VPNSessionNotFoundError{ID: sessionID} })
+}
+
 // GetVPNSessionTasks retrieves a list of VPN session tasks
 func (s *Service) GetVPNSessionTasks(sessionID string, parameters connection.APIRequestParameters) ([]Task, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPNSessionTasksPaginated(sessionID, p)
-	}, parameters)
+	return s.vpnSessionTasksRes().List(sessionID, parameters)
 }
 
 // GetVPNSessionTasksPaginated retrieves a paginated list of VPN session tasks
 func (s *Service) GetVPNSessionTasksPaginated(sessionID string, parameters connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-	if sessionID == "" {
-		return nil, fmt.Errorf("invalid vpn session id")
-	}
-	body, err := connection.Get[[]Task](s.connection, fmt.Sprintf("/ecloud/v2/vpn-sessions/%s/tasks", sessionID), parameters, connection.NotFoundResponseHandler(&VPNSessionNotFoundError{ID: sessionID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Task], error) {
-		return s.GetVPNSessionTasksPaginated(sessionID, p)
-	}), err
+	return s.vpnSessionTasksRes().ListPaginated(sessionID, parameters)
 }
 
 // GetVPNSessionPreSharedKey retrieves a single VPN session by id

--- a/pkg/service/internal/resource/subresource.go
+++ b/pkg/service/internal/resource/subresource.go
@@ -1,0 +1,231 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/ans-group/sdk-go/pkg/connection"
+)
+
+// SubResourceList handles list-only operations for resources nested under a parent.
+type SubResourceList[T any, ParentID comparable] struct {
+	conn           connection.Connection
+	basePath       func(ParentID) string
+	name           string
+	identifier     string
+	validateParent func(ParentID) bool
+	parentNotFound func(ParentID) error
+}
+
+// NewStringSubResourceList creates a SubResourceList with a string parent ID (valid when non-empty).
+func NewStringSubResourceList[T any](conn connection.Connection, basePath func(string) string, name, identifier string, parentNotFound func(string) error) *SubResourceList[T, string] {
+	return &SubResourceList[T, string]{
+		conn: conn, basePath: basePath, name: name, identifier: identifier,
+		validateParent: func(id string) bool { return id != "" },
+		parentNotFound: parentNotFound,
+	}
+}
+
+// NewIntSubResourceList creates a SubResourceList with an int parent ID (valid when > 0).
+func NewIntSubResourceList[T any](conn connection.Connection, basePath func(int) string, name, identifier string, parentNotFound func(int) error) *SubResourceList[T, int] {
+	return &SubResourceList[T, int]{
+		conn: conn, basePath: basePath, name: name, identifier: identifier,
+		validateParent: func(id int) bool { return id > 0 },
+		parentNotFound: parentNotFound,
+	}
+}
+
+// NewUncheckedStringSubResourceList creates a SubResourceList with no parent validation or not-found handler.
+func NewUncheckedStringSubResourceList[T any](conn connection.Connection, basePath func(string) string) *SubResourceList[T, string] {
+	return &SubResourceList[T, string]{conn: conn, basePath: basePath}
+}
+
+func (r *SubResourceList[T, ParentID]) List(parentID ParentID, params connection.APIRequestParameters) ([]T, error) {
+	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[T], error) {
+		return r.ListPaginated(parentID, p)
+	}, params)
+}
+
+func (r *SubResourceList[T, ParentID]) ListPaginated(parentID ParentID, params connection.APIRequestParameters) (*connection.Paginated[T], error) {
+	if r.validateParent != nil && !r.validateParent(parentID) {
+		return nil, fmt.Errorf("invalid %s %s", r.name, r.identifier)
+	}
+	var handlers []connection.ResponseHandler
+	if r.parentNotFound != nil {
+		handlers = append(handlers, connection.NotFoundResponseHandler(r.parentNotFound(parentID)))
+	}
+	body, err := connection.Get[[]T](r.conn, r.basePath(parentID), params, handlers...)
+	return connection.NewPaginated(body, params, func(p connection.APIRequestParameters) (*connection.Paginated[T], error) {
+		return r.ListPaginated(parentID, p)
+	}), err
+}
+
+// SubResource handles CRUD operations for resources nested under a parent.
+type SubResource[T any, ParentID comparable, ChildID comparable] struct {
+	conn             connection.Connection
+	basePath         func(ParentID) string
+	parentName       string
+	parentIdentifier string
+	childName        string
+	childIdentifier  string
+	validateParent   func(ParentID) bool
+	validateChild    func(ChildID) bool
+	parentNotFound   func(ParentID) error
+	childNotFound    func(ParentID, ChildID) error
+}
+
+// NewStringIntSubResource creates a SubResource with a string parent ID and int child ID.
+func NewStringIntSubResource[T any](
+	conn connection.Connection,
+	basePath func(string) string,
+	parentName, parentIdentifier string,
+	parentNotFound func(string) error,
+	childName, childIdentifier string,
+	childNotFound func(string, int) error,
+) *SubResource[T, string, int] {
+	return &SubResource[T, string, int]{
+		conn: conn, basePath: basePath,
+		parentName: parentName, parentIdentifier: parentIdentifier,
+		childName: childName, childIdentifier: childIdentifier,
+		validateParent: func(id string) bool { return id != "" },
+		validateChild:  func(id int) bool { return id > 0 },
+		parentNotFound: parentNotFound,
+		childNotFound:  childNotFound,
+	}
+}
+
+// NewIntIntSubResource creates a SubResource with int parent and child IDs.
+func NewIntIntSubResource[T any](
+	conn connection.Connection,
+	basePath func(int) string,
+	parentName, parentIdentifier string,
+	parentNotFound func(int) error,
+	childName, childIdentifier string,
+	childNotFound func(int, int) error,
+) *SubResource[T, int, int] {
+	return &SubResource[T, int, int]{
+		conn: conn, basePath: basePath,
+		parentName: parentName, parentIdentifier: parentIdentifier,
+		childName: childName, childIdentifier: childIdentifier,
+		validateParent: func(id int) bool { return id > 0 },
+		validateChild:  func(id int) bool { return id > 0 },
+		parentNotFound: parentNotFound,
+		childNotFound:  childNotFound,
+	}
+}
+
+// NewStringStringSubResource creates a SubResource with string parent and child IDs.
+func NewStringStringSubResource[T any](
+	conn connection.Connection,
+	basePath func(string) string,
+	parentName, parentIdentifier string,
+	parentNotFound func(string) error,
+	childName, childIdentifier string,
+	childNotFound func(string, string) error,
+) *SubResource[T, string, string] {
+	return &SubResource[T, string, string]{
+		conn: conn, basePath: basePath,
+		parentName: parentName, parentIdentifier: parentIdentifier,
+		childName: childName, childIdentifier: childIdentifier,
+		validateParent: func(id string) bool { return id != "" },
+		validateChild:  func(id string) bool { return id != "" },
+		parentNotFound: parentNotFound,
+		childNotFound:  childNotFound,
+	}
+}
+
+func (r *SubResource[T, ParentID, ChildID]) List(parentID ParentID, params connection.APIRequestParameters) ([]T, error) {
+	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[T], error) {
+		return r.ListPaginated(parentID, p)
+	}, params)
+}
+
+func (r *SubResource[T, ParentID, ChildID]) ListPaginated(parentID ParentID, params connection.APIRequestParameters) (*connection.Paginated[T], error) {
+	if r.validateParent != nil && !r.validateParent(parentID) {
+		return nil, fmt.Errorf("invalid %s %s", r.parentName, r.parentIdentifier)
+	}
+	var handlers []connection.ResponseHandler
+	if r.parentNotFound != nil {
+		handlers = append(handlers, connection.NotFoundResponseHandler(r.parentNotFound(parentID)))
+	}
+	body, err := connection.Get[[]T](r.conn, r.basePath(parentID), params, handlers...)
+	return connection.NewPaginated(body, params, func(p connection.APIRequestParameters) (*connection.Paginated[T], error) {
+		return r.ListPaginated(parentID, p)
+	}), err
+}
+
+func (r *SubResource[T, ParentID, ChildID]) Get(parentID ParentID, childID ChildID) (T, error) {
+	var zero T
+	if r.validateParent != nil && !r.validateParent(parentID) {
+		return zero, fmt.Errorf("invalid %s %s", r.parentName, r.parentIdentifier)
+	}
+	if r.validateChild != nil && !r.validateChild(childID) {
+		return zero, fmt.Errorf("invalid %s %s", r.childName, r.childIdentifier)
+	}
+	body, err := connection.Get[T](r.conn, fmt.Sprintf("%s/%v", r.basePath(parentID), childID), connection.APIRequestParameters{},
+		connection.NotFoundResponseHandler(r.childNotFound(parentID, childID)))
+	return body.Data, err
+}
+
+func (r *SubResource[T, ParentID, ChildID]) Create(parentID ParentID, req any) (T, error) {
+	var zero T
+	if r.validateParent != nil && !r.validateParent(parentID) {
+		return zero, fmt.Errorf("invalid %s %s", r.parentName, r.parentIdentifier)
+	}
+	var handlers []connection.ResponseHandler
+	if r.parentNotFound != nil {
+		handlers = append(handlers, connection.NotFoundResponseHandler(r.parentNotFound(parentID)))
+	}
+	body, err := connection.Post[T](r.conn, r.basePath(parentID), req, handlers...)
+	return body.Data, err
+}
+
+// Update performs a PUT on the child resource and returns the updated object.
+func (r *SubResource[T, ParentID, ChildID]) Update(parentID ParentID, childID ChildID, req any) (T, error) {
+	var zero T
+	if r.validateParent != nil && !r.validateParent(parentID) {
+		return zero, fmt.Errorf("invalid %s %s", r.parentName, r.parentIdentifier)
+	}
+	if r.validateChild != nil && !r.validateChild(childID) {
+		return zero, fmt.Errorf("invalid %s %s", r.childName, r.childIdentifier)
+	}
+	body, err := connection.Put[T](r.conn, fmt.Sprintf("%s/%v", r.basePath(parentID), childID), req,
+		connection.NotFoundResponseHandler(r.childNotFound(parentID, childID)))
+	return body.Data, err
+}
+
+// Patch performs a PATCH on the child resource (returns error only).
+func (r *SubResource[T, ParentID, ChildID]) Patch(parentID ParentID, childID ChildID, req any) error {
+	if r.validateParent != nil && !r.validateParent(parentID) {
+		return fmt.Errorf("invalid %s %s", r.parentName, r.parentIdentifier)
+	}
+	if r.validateChild != nil && !r.validateChild(childID) {
+		return fmt.Errorf("invalid %s %s", r.childName, r.childIdentifier)
+	}
+	return connection.PatchRaw(r.conn, fmt.Sprintf("%s/%v", r.basePath(parentID), childID), req, &connection.APIResponseBody{},
+		connection.NotFoundResponseHandler(r.childNotFound(parentID, childID)))
+}
+
+// PatchReturning performs a PATCH on the child resource and returns the patched object.
+func (r *SubResource[T, ParentID, ChildID]) PatchReturning(parentID ParentID, childID ChildID, req any) (T, error) {
+	var zero T
+	if r.validateParent != nil && !r.validateParent(parentID) {
+		return zero, fmt.Errorf("invalid %s %s", r.parentName, r.parentIdentifier)
+	}
+	if r.validateChild != nil && !r.validateChild(childID) {
+		return zero, fmt.Errorf("invalid %s %s", r.childName, r.childIdentifier)
+	}
+	body, err := connection.Patch[T](r.conn, fmt.Sprintf("%s/%v", r.basePath(parentID), childID), req,
+		connection.NotFoundResponseHandler(r.childNotFound(parentID, childID)))
+	return body.Data, err
+}
+
+func (r *SubResource[T, ParentID, ChildID]) Delete(parentID ParentID, childID ChildID) error {
+	if r.validateParent != nil && !r.validateParent(parentID) {
+		return fmt.Errorf("invalid %s %s", r.parentName, r.parentIdentifier)
+	}
+	if r.validateChild != nil && !r.validateChild(childID) {
+		return fmt.Errorf("invalid %s %s", r.childName, r.childIdentifier)
+	}
+	return connection.DeleteRaw(r.conn, fmt.Sprintf("%s/%v", r.basePath(parentID), childID), nil, &connection.APIResponseBody{},
+		connection.NotFoundResponseHandler(r.childNotFound(parentID, childID)))
+}

--- a/pkg/service/internal/resource/subresource_test.go
+++ b/pkg/service/internal/resource/subresource_test.go
@@ -1,0 +1,516 @@
+package resource_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/internal/resource"
+	"github.com/ans-group/sdk-go/test/mocks"
+)
+
+// childModel and error types used in sub-resource tests
+
+type childModel struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type parentNotFoundError struct {
+	ParentID string
+}
+
+func (e *parentNotFoundError) Error() string {
+	return fmt.Sprintf("parent not found [%s]", e.ParentID)
+}
+
+type childNotFoundError struct {
+	ChildID int
+}
+
+func (e *childNotFoundError) Error() string {
+	return fmt.Sprintf("child not found [%d]", e.ChildID)
+}
+
+// helpers to build reusable SubResourceList and SubResource instances
+
+func newStringSubResourceList(c connection.Connection) *resource.SubResourceList[childModel, string] {
+	return resource.NewStringSubResourceList[childModel](c,
+		func(parentID string) string { return fmt.Sprintf("/test/v1/parents/%s/children", parentID) },
+		"parent", "id",
+		func(parentID string) error { return &parentNotFoundError{ParentID: parentID} })
+}
+
+func newUncheckedSubResourceList(c connection.Connection) *resource.SubResourceList[childModel, string] {
+	return resource.NewUncheckedStringSubResourceList[childModel](c,
+		func(parentID string) string { return fmt.Sprintf("/test/v1/parents/%s/children", parentID) })
+}
+
+func newStringIntSubResource(c connection.Connection) *resource.SubResource[childModel, string, int] {
+	return resource.NewStringIntSubResource[childModel](c,
+		func(parentID string) string { return fmt.Sprintf("/test/v1/parents/%s/children", parentID) },
+		"parent", "id",
+		func(parentID string) error { return &parentNotFoundError{ParentID: parentID} },
+		"child", "id",
+		func(_ string, childID int) error { return &childNotFoundError{ChildID: childID} })
+}
+
+// --- SubResourceList ---
+
+func TestSubResourceList_List(t *testing.T) {
+	t.Run("Single", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents/p1/children", gomock.Any()).Return(
+			apiResponseJSON(200, `{"data":[{"id":1,"name":"foo"}],"meta":{"pagination":{"total_pages":1}}}`), nil).Times(1)
+
+		items, err := newStringSubResourceList(c).List("p1", connection.APIRequestParameters{})
+
+		assert.Nil(t, err)
+		assert.Len(t, items, 1)
+		assert.Equal(t, 1, items[0].ID)
+	})
+
+	t.Run("MultiPage", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		gomock.InOrder(
+			c.EXPECT().Get("/test/v1/parents/p1/children", gomock.Any()).Return(
+				apiResponseJSON(200, `{"data":[{"id":1}],"meta":{"pagination":{"total_pages":2}}}`), nil),
+			c.EXPECT().Get("/test/v1/parents/p1/children", gomock.Any()).Return(
+				apiResponseJSON(200, `{"data":[{"id":2}],"meta":{"pagination":{"total_pages":2}}}`), nil),
+		)
+
+		items, err := newStringSubResourceList(c).List("p1", connection.APIRequestParameters{})
+
+		assert.Nil(t, err)
+		assert.Len(t, items, 2)
+	})
+}
+
+func TestSubResourceList_ListPaginated(t *testing.T) {
+	t.Run("Valid_ReturnsPaginated", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents/p1/children", gomock.Any()).Return(
+			apiResponseJSON(200, `{"data":[{"id":1}],"meta":{"pagination":{"total_pages":1}}}`), nil).Times(1)
+
+		page, err := newStringSubResourceList(c).ListPaginated("p1", connection.APIRequestParameters{})
+
+		assert.Nil(t, err)
+		assert.Len(t, page.Items(), 1)
+	})
+
+	t.Run("EmptyParentID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		_, err := newStringSubResourceList(c).ListPaginated("", connection.APIRequestParameters{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid parent id", err.Error())
+	})
+
+	t.Run("NotFound_ReturnsParentNotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents/p1/children", gomock.Any()).Return(
+			apiResponseJSON(404, ""), nil).Times(1)
+
+		_, err := newStringSubResourceList(c).ListPaginated("p1", connection.APIRequestParameters{})
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &parentNotFoundError{}, err)
+	})
+
+	t.Run("ConnectionError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents/p1/children", gomock.Any()).Return(
+			&connection.APIResponse{}, errors.New("test error"))
+
+		_, err := newStringSubResourceList(c).ListPaginated("p1", connection.APIRequestParameters{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "test error", err.Error())
+	})
+}
+
+func TestSubResourceList_Unchecked(t *testing.T) {
+	t.Run("EmptyParentID_DoesNotValidate", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents//children", gomock.Any()).Return(
+			apiResponseJSON(200, `{"data":[],"meta":{"pagination":{"total_pages":1}}}`), nil).Times(1)
+
+		_, err := newUncheckedSubResourceList(c).ListPaginated("", connection.APIRequestParameters{})
+
+		assert.Nil(t, err)
+	})
+}
+
+// --- SubResource ---
+
+func TestSubResource_ListPaginated(t *testing.T) {
+	t.Run("Valid_ReturnsPaginated", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents/p1/children", gomock.Any()).Return(
+			apiResponseJSON(200, `{"data":[{"id":1}],"meta":{"pagination":{"total_pages":1}}}`), nil).Times(1)
+
+		page, err := newStringIntSubResource(c).ListPaginated("p1", connection.APIRequestParameters{})
+
+		assert.Nil(t, err)
+		assert.Len(t, page.Items(), 1)
+	})
+
+	t.Run("EmptyParentID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		_, err := newStringIntSubResource(c).ListPaginated("", connection.APIRequestParameters{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid parent id", err.Error())
+	})
+
+	t.Run("NotFound_ReturnsParentNotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents/p1/children", gomock.Any()).Return(
+			apiResponseJSON(404, ""), nil).Times(1)
+
+		_, err := newStringIntSubResource(c).ListPaginated("p1", connection.APIRequestParameters{})
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &parentNotFoundError{}, err)
+	})
+}
+
+func TestSubResource_Get(t *testing.T) {
+	t.Run("Valid_ReturnsItem", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(200, `{"data":{"id":42,"name":"child"}}`), nil).Times(1)
+
+		item, err := newStringIntSubResource(c).Get("p1", 42)
+
+		assert.Nil(t, err)
+		assert.Equal(t, 42, item.ID)
+	})
+
+	t.Run("EmptyParentID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		_, err := newStringIntSubResource(c).Get("", 42)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid parent id", err.Error())
+	})
+
+	t.Run("ZeroChildID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		_, err := newStringIntSubResource(c).Get("p1", 0)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid child id", err.Error())
+	})
+
+	t.Run("NotFound_ReturnsChildNotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(404, ""), nil).Times(1)
+
+		_, err := newStringIntSubResource(c).Get("p1", 42)
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &childNotFoundError{}, err)
+	})
+
+	t.Run("ConnectionError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Get("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			&connection.APIResponse{}, errors.New("test error"))
+
+		_, err := newStringIntSubResource(c).Get("p1", 42)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "test error", err.Error())
+	})
+}
+
+func TestSubResource_Create(t *testing.T) {
+	t.Run("Valid_ReturnsCreated", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Post("/test/v1/parents/p1/children", gomock.Any()).Return(
+			apiResponseJSON(201, `{"data":{"id":99,"name":"new"}}`), nil).Times(1)
+
+		item, err := newStringIntSubResource(c).Create("p1", struct{}{})
+
+		assert.Nil(t, err)
+		assert.Equal(t, 99, item.ID)
+	})
+
+	t.Run("EmptyParentID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		_, err := newStringIntSubResource(c).Create("", struct{}{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid parent id", err.Error())
+	})
+
+	t.Run("NotFound_ReturnsParentNotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Post("/test/v1/parents/p1/children", gomock.Any()).Return(
+			apiResponseJSON(404, ""), nil).Times(1)
+
+		_, err := newStringIntSubResource(c).Create("p1", struct{}{})
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &parentNotFoundError{}, err)
+	})
+}
+
+func TestSubResource_Patch(t *testing.T) {
+	t.Run("Valid_ReturnsNil", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Patch("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(200, ""), nil).Times(1)
+
+		err := newStringIntSubResource(c).Patch("p1", 42, struct{}{})
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("EmptyParentID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		err := newStringIntSubResource(c).Patch("", 42, struct{}{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid parent id", err.Error())
+	})
+
+	t.Run("ZeroChildID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		err := newStringIntSubResource(c).Patch("p1", 0, struct{}{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid child id", err.Error())
+	})
+
+	t.Run("NotFound_ReturnsChildNotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Patch("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(404, ""), nil).Times(1)
+
+		err := newStringIntSubResource(c).Patch("p1", 42, struct{}{})
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &childNotFoundError{}, err)
+	})
+}
+
+func TestSubResource_PatchReturning(t *testing.T) {
+	t.Run("Valid_ReturnsItem", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Patch("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(200, `{"data":{"id":42,"name":"updated"}}`), nil).Times(1)
+
+		item, err := newStringIntSubResource(c).PatchReturning("p1", 42, struct{}{})
+
+		assert.Nil(t, err)
+		assert.Equal(t, 42, item.ID)
+		assert.Equal(t, "updated", item.Name)
+	})
+
+	t.Run("EmptyParentID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		_, err := newStringIntSubResource(c).PatchReturning("", 42, struct{}{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid parent id", err.Error())
+	})
+
+	t.Run("ZeroChildID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		_, err := newStringIntSubResource(c).PatchReturning("p1", 0, struct{}{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid child id", err.Error())
+	})
+
+	t.Run("NotFound_ReturnsChildNotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Patch("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(404, ""), nil).Times(1)
+
+		_, err := newStringIntSubResource(c).PatchReturning("p1", 42, struct{}{})
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &childNotFoundError{}, err)
+	})
+}
+
+func TestSubResource_Update(t *testing.T) {
+	t.Run("Valid_ReturnsUpdated", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Put("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(200, `{"data":{"id":42,"name":"updated"}}`), nil).Times(1)
+
+		item, err := newStringIntSubResource(c).Update("p1", 42, struct{}{})
+
+		assert.Nil(t, err)
+		assert.Equal(t, 42, item.ID)
+	})
+
+	t.Run("EmptyParentID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		_, err := newStringIntSubResource(c).Update("", 42, struct{}{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid parent id", err.Error())
+	})
+
+	t.Run("ZeroChildID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		_, err := newStringIntSubResource(c).Update("p1", 0, struct{}{})
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid child id", err.Error())
+	})
+
+	t.Run("NotFound_ReturnsChildNotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Put("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(404, ""), nil).Times(1)
+
+		_, err := newStringIntSubResource(c).Update("p1", 42, struct{}{})
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &childNotFoundError{}, err)
+	})
+}
+
+func TestSubResource_Delete(t *testing.T) {
+	t.Run("Valid_ReturnsNil", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Delete("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(204, ""), nil).Times(1)
+
+		err := newStringIntSubResource(c).Delete("p1", 42)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("EmptyParentID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		err := newStringIntSubResource(c).Delete("", 42)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid parent id", err.Error())
+	})
+
+	t.Run("ZeroChildID_ReturnsValidationError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+
+		err := newStringIntSubResource(c).Delete("p1", 0)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "invalid child id", err.Error())
+	})
+
+	t.Run("NotFound_ReturnsChildNotFoundError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Delete("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			apiResponseJSON(404, ""), nil).Times(1)
+
+		err := newStringIntSubResource(c).Delete("p1", 42)
+
+		assert.NotNil(t, err)
+		assert.IsType(t, &childNotFoundError{}, err)
+	})
+
+	t.Run("ConnectionError_ReturnsError", func(t *testing.T) {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		c := mocks.NewMockConnection(mockCtrl)
+		c.EXPECT().Delete("/test/v1/parents/p1/children/42", gomock.Any()).Return(
+			&connection.APIResponse{}, errors.New("test error"))
+
+		err := newStringIntSubResource(c).Delete("p1", 42)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, "test error", err.Error())
+	})
+}

--- a/pkg/service/loadbalancer/service_listener_accessip.go
+++ b/pkg/service/loadbalancer/service_listener_accessip.go
@@ -4,43 +4,35 @@ import (
 	"fmt"
 
 	"github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/internal/resource"
 )
+
+func (s *Service) listenerAccessIPRes() *resource.SubResource[AccessIP, int, int] {
+	return resource.NewIntIntSubResource[AccessIP](s.connection,
+		func(listenerID int) string {
+			return fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips", listenerID)
+		},
+		"listener", "id", func(listenerID int) error { return &AccessIPNotFoundError{ID: listenerID} },
+		"access", "id", func(listenerID, _ int) error { return &AccessIPNotFoundError{ID: listenerID} })
+}
 
 // GetListenerAccessIPs retrieves a list of access IPs
 func (s *Service) GetListenerAccessIPs(listenerID int, parameters connection.APIRequestParameters) ([]AccessIP, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[AccessIP], error) {
-		return s.GetListenerAccessIPsPaginated(listenerID, p)
-	}, parameters)
+	return s.listenerAccessIPRes().List(listenerID, parameters)
 }
 
 // GetListenerAccessIPsPaginated retrieves a paginated list of access IPs
 func (s *Service) GetListenerAccessIPsPaginated(listenerID int, parameters connection.APIRequestParameters) (*connection.Paginated[AccessIP], error) {
-	if listenerID < 1 {
-		return nil, fmt.Errorf("invalid listener id")
-	}
-	body, err := connection.Get[[]AccessIP](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips", listenerID), parameters)
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[AccessIP], error) {
-		return s.GetListenerAccessIPsPaginated(listenerID, p)
-	}), err
+	return s.listenerAccessIPRes().ListPaginated(listenerID, parameters)
 }
 
 // GetListenerAccessIP retrieves a single access IP by id
 func (s *Service) GetListenerAccessIP(listenerID int, accessID int) (AccessIP, error) {
-	if listenerID < 1 {
-		return AccessIP{}, fmt.Errorf("invalid listener id")
-	}
-	if accessID < 1 {
-		return AccessIP{}, fmt.Errorf("invalid access id")
-	}
-	body, err := connection.Get[AccessIP](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips/%d", listenerID, accessID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&AccessIPNotFoundError{ID: listenerID}))
-	return body.Data, err
+	return s.listenerAccessIPRes().Get(listenerID, accessID)
 }
 
 // CreateListenerAccessIP creates an access IP
 func (s *Service) CreateListenerAccessIP(listenerID int, req CreateAccessIPRequest) (int, error) {
-	if listenerID < 1 {
-		return 0, fmt.Errorf("invalid listener id")
-	}
-	body, err := connection.Post[AccessIP](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/access-ips", listenerID), &req, connection.NotFoundResponseHandler(&AccessIPNotFoundError{ID: listenerID}))
-	return body.Data.ID, err
+	accessIP, err := s.listenerAccessIPRes().Create(listenerID, &req)
+	return accessIP.ID, err
 }

--- a/pkg/service/loadbalancer/service_listener_acl.go
+++ b/pkg/service/loadbalancer/service_listener_acl.go
@@ -4,22 +4,21 @@ import (
 	"fmt"
 
 	"github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/internal/resource"
 )
+
+func (s *Service) listenerACLRes() *resource.SubResourceList[ACL, int] {
+	return resource.NewIntSubResourceList[ACL](s.connection,
+		func(listenerID int) string { return fmt.Sprintf("/loadbalancers/v2/listeners/%d/acls", listenerID) },
+		"listener", "id", nil)
+}
 
 // GetListenerACLs retrieves a list of ACLs
 func (s *Service) GetListenerACLs(listenerID int, parameters connection.APIRequestParameters) ([]ACL, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
-		return s.GetListenerACLsPaginated(listenerID, p)
-	}, parameters)
+	return s.listenerACLRes().List(listenerID, parameters)
 }
 
 // GetListenerACLsPaginated retrieves a paginated list of ACLs
 func (s *Service) GetListenerACLsPaginated(listenerID int, parameters connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
-	if listenerID < 1 {
-		return nil, fmt.Errorf("invalid listener id")
-	}
-	body, err := connection.Get[[]ACL](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/acls", listenerID), parameters)
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
-		return s.GetListenerACLsPaginated(listenerID, p)
-	}), err
+	return s.listenerACLRes().ListPaginated(listenerID, parameters)
 }

--- a/pkg/service/loadbalancer/service_listener_bind.go
+++ b/pkg/service/loadbalancer/service_listener_bind.go
@@ -4,65 +4,43 @@ import (
 	"fmt"
 
 	"github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/internal/resource"
 )
+
+func (s *Service) listenerBindRes() *resource.SubResource[Bind, int, int] {
+	return resource.NewIntIntSubResource[Bind](s.connection,
+		func(listenerID int) string { return fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds", listenerID) },
+		"listener", "id", func(listenerID int) error { return &ListenerNotFoundError{ID: listenerID} },
+		"bind", "id", func(_, bindID int) error { return &BindNotFoundError{ID: bindID} })
+}
 
 // GetListenerBinds retrieves a list of binds
 func (s *Service) GetListenerBinds(listenerID int, parameters connection.APIRequestParameters) ([]Bind, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Bind], error) {
-		return s.GetListenerBindsPaginated(listenerID, p)
-	}, parameters)
+	return s.listenerBindRes().List(listenerID, parameters)
 }
 
 // GetListenerBindsPaginated retrieves a paginated list of binds
 func (s *Service) GetListenerBindsPaginated(listenerID int, parameters connection.APIRequestParameters) (*connection.Paginated[Bind], error) {
-	if listenerID < 1 {
-		return nil, fmt.Errorf("invalid listener id")
-	}
-	body, err := connection.Get[[]Bind](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds", listenerID), parameters)
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Bind], error) {
-		return s.GetListenerBindsPaginated(listenerID, p)
-	}), err
+	return s.listenerBindRes().ListPaginated(listenerID, parameters)
 }
 
 // GetListenerBind retrieves a single bind by id
 func (s *Service) GetListenerBind(listenerID int, bindID int) (Bind, error) {
-	if listenerID < 1 {
-		return Bind{}, fmt.Errorf("invalid listener id")
-	}
-	if bindID < 1 {
-		return Bind{}, fmt.Errorf("invalid bind id")
-	}
-	body, err := connection.Get[Bind](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds/%d", listenerID, bindID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&BindNotFoundError{ID: listenerID}))
-	return body.Data, err
+	return s.listenerBindRes().Get(listenerID, bindID)
 }
 
 // CreateListenerBind creates an bind
 func (s *Service) CreateListenerBind(listenerID int, req CreateBindRequest) (int, error) {
-	if listenerID < 1 {
-		return 0, fmt.Errorf("invalid listener id")
-	}
-	body, err := connection.Post[Bind](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds", listenerID), &req, connection.NotFoundResponseHandler(&BindNotFoundError{ID: listenerID}))
-	return body.Data.ID, err
+	bind, err := s.listenerBindRes().Create(listenerID, &req)
+	return bind.ID, err
 }
 
 // PatchListenerBind patches an bind
 func (s *Service) PatchListenerBind(listenerID int, bindID int, req PatchBindRequest) error {
-	if listenerID < 1 {
-		return fmt.Errorf("invalid listener id")
-	}
-	if bindID < 1 {
-		return fmt.Errorf("invalid bind id")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds/%d", listenerID, bindID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&BindNotFoundError{ID: listenerID}))
+	return s.listenerBindRes().Patch(listenerID, bindID, &req)
 }
 
 // DeleteListenerBind deletes a bind
 func (s *Service) DeleteListenerBind(listenerID int, bindID int) error {
-	if listenerID < 1 {
-		return fmt.Errorf("invalid listener id")
-	}
-	if bindID < 1 {
-		return fmt.Errorf("invalid bind id")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/binds/%d", listenerID, bindID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&BindNotFoundError{ID: listenerID}))
+	return s.listenerBindRes().Delete(listenerID, bindID)
 }

--- a/pkg/service/loadbalancer/service_listener_bind_test.go
+++ b/pkg/service/loadbalancer/service_listener_bind_test.go
@@ -233,7 +233,7 @@ func TestCreateListenerBind(t *testing.T) {
 		assert.Equal(t, "invalid listener id", err.Error())
 	})
 
-	t.Run("404_ReturnsListenerBindNotFoundError", func(t *testing.T) {
+	t.Run("404_ReturnsListenerNotFoundError", func(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -253,7 +253,7 @@ func TestCreateListenerBind(t *testing.T) {
 		_, err := s.CreateListenerBind(123, CreateBindRequest{})
 
 		assert.NotNil(t, err)
-		assert.IsType(t, &BindNotFoundError{}, err)
+		assert.IsType(t, &ListenerNotFoundError{}, err)
 	})
 }
 

--- a/pkg/service/loadbalancer/service_listener_certificate.go
+++ b/pkg/service/loadbalancer/service_listener_certificate.go
@@ -4,65 +4,43 @@ import (
 	"fmt"
 
 	"github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/internal/resource"
 )
+
+func (s *Service) listenerCertRes() *resource.SubResource[Certificate, int, int] {
+	return resource.NewIntIntSubResource[Certificate](s.connection,
+		func(listenerID int) string { return fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs", listenerID) },
+		"listener", "id", func(listenerID int) error { return &CertificateNotFoundError{ID: listenerID} },
+		"certificate", "id", func(listenerID, _ int) error { return &CertificateNotFoundError{ID: listenerID} })
+}
 
 // GetListenerCertificates retrieves a list of certificates
 func (s *Service) GetListenerCertificates(listenerID int, parameters connection.APIRequestParameters) ([]Certificate, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Certificate], error) {
-		return s.GetListenerCertificatesPaginated(listenerID, p)
-	}, parameters)
+	return s.listenerCertRes().List(listenerID, parameters)
 }
 
 // GetListenerCertificatesPaginated retrieves a paginated list of certificates
 func (s *Service) GetListenerCertificatesPaginated(listenerID int, parameters connection.APIRequestParameters) (*connection.Paginated[Certificate], error) {
-	if listenerID < 1 {
-		return nil, fmt.Errorf("invalid listener id")
-	}
-	body, err := connection.Get[[]Certificate](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs", listenerID), parameters)
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Certificate], error) {
-		return s.GetListenerCertificatesPaginated(listenerID, p)
-	}), err
+	return s.listenerCertRes().ListPaginated(listenerID, parameters)
 }
 
 // GetListenerCertificate retrieves a single certificate by id
 func (s *Service) GetListenerCertificate(listenerID int, certificateID int) (Certificate, error) {
-	if listenerID < 1 {
-		return Certificate{}, fmt.Errorf("invalid listener id")
-	}
-	if certificateID < 1 {
-		return Certificate{}, fmt.Errorf("invalid certificate id")
-	}
-	body, err := connection.Get[Certificate](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs/%d", listenerID, certificateID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: listenerID}))
-	return body.Data, err
+	return s.listenerCertRes().Get(listenerID, certificateID)
 }
 
 // CreateListenerCertificate creates an certificate
 func (s *Service) CreateListenerCertificate(listenerID int, req CreateCertificateRequest) (int, error) {
-	if listenerID < 1 {
-		return 0, fmt.Errorf("invalid listener id")
-	}
-	body, err := connection.Post[Certificate](s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs", listenerID), &req, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: listenerID}))
-	return body.Data.ID, err
+	cert, err := s.listenerCertRes().Create(listenerID, &req)
+	return cert.ID, err
 }
 
 // PatchListenerCertificate patches an certificate
 func (s *Service) PatchListenerCertificate(listenerID int, certificateID int, req PatchCertificateRequest) error {
-	if listenerID < 1 {
-		return fmt.Errorf("invalid listener id")
-	}
-	if certificateID < 1 {
-		return fmt.Errorf("invalid certificate id")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs/%d", listenerID, certificateID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: listenerID}))
+	return s.listenerCertRes().Patch(listenerID, certificateID, &req)
 }
 
 // DeleteListenerCertificate deletes a certificate
 func (s *Service) DeleteListenerCertificate(listenerID int, certificateID int) error {
-	if listenerID < 1 {
-		return fmt.Errorf("invalid listener id")
-	}
-	if certificateID < 1 {
-		return fmt.Errorf("invalid certificate id")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/listeners/%d/certs/%d", listenerID, certificateID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&CertificateNotFoundError{ID: listenerID}))
+	return s.listenerCertRes().Delete(listenerID, certificateID)
 }

--- a/pkg/service/loadbalancer/service_targetgroup_acl.go
+++ b/pkg/service/loadbalancer/service_targetgroup_acl.go
@@ -4,22 +4,23 @@ import (
 	"fmt"
 
 	"github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/internal/resource"
 )
+
+func (s *Service) targetGroupACLRes() *resource.SubResourceList[ACL, int] {
+	return resource.NewIntSubResourceList[ACL](s.connection,
+		func(targetGroupID int) string {
+			return fmt.Sprintf("/loadbalancers/v2/target-groups/%d/acls", targetGroupID)
+		},
+		"target group", "id", nil)
+}
 
 // GetTargetGroupACLs retrieves a list of ACLs
 func (s *Service) GetTargetGroupACLs(targetGroupID int, parameters connection.APIRequestParameters) ([]ACL, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
-		return s.GetTargetGroupACLsPaginated(targetGroupID, p)
-	}, parameters)
+	return s.targetGroupACLRes().List(targetGroupID, parameters)
 }
 
 // GetTargetGroupACLsPaginated retrieves a paginated list of ACLs
 func (s *Service) GetTargetGroupACLsPaginated(targetGroupID int, parameters connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
-	if targetGroupID < 1 {
-		return nil, fmt.Errorf("invalid target group id")
-	}
-	body, err := connection.Get[[]ACL](s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/acls", targetGroupID), parameters)
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[ACL], error) {
-		return s.GetTargetGroupACLsPaginated(targetGroupID, p)
-	}), err
+	return s.targetGroupACLRes().ListPaginated(targetGroupID, parameters)
 }

--- a/pkg/service/loadbalancer/service_targetgroup_target.go
+++ b/pkg/service/loadbalancer/service_targetgroup_target.go
@@ -4,65 +4,43 @@ import (
 	"fmt"
 
 	"github.com/ans-group/sdk-go/pkg/connection"
+	"github.com/ans-group/sdk-go/pkg/service/internal/resource"
 )
+
+func (s *Service) targetGroupTargetRes() *resource.SubResource[Target, int, int] {
+	return resource.NewIntIntSubResource[Target](s.connection,
+		func(groupID int) string { return fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets", groupID) },
+		"target group", "id", func(groupID int) error { return &TargetNotFoundError{ID: groupID} },
+		"target", "id", func(groupID, _ int) error { return &TargetNotFoundError{ID: groupID} })
+}
 
 // GetTargetGroupTargets retrieves a list of targets
 func (s *Service) GetTargetGroupTargets(groupID int, parameters connection.APIRequestParameters) ([]Target, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Target], error) {
-		return s.GetTargetGroupTargetsPaginated(groupID, p)
-	}, parameters)
+	return s.targetGroupTargetRes().List(groupID, parameters)
 }
 
 // GetTargetGroupTargetsPaginated retrieves a paginated list of targets
 func (s *Service) GetTargetGroupTargetsPaginated(groupID int, parameters connection.APIRequestParameters) (*connection.Paginated[Target], error) {
-	if groupID < 1 {
-		return nil, fmt.Errorf("invalid target group id")
-	}
-	body, err := connection.Get[[]Target](s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets", groupID), parameters)
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Target], error) {
-		return s.GetTargetGroupTargetsPaginated(groupID, p)
-	}), err
+	return s.targetGroupTargetRes().ListPaginated(groupID, parameters)
 }
 
 // GetTargetGroupTarget retrieves a single target by id
 func (s *Service) GetTargetGroupTarget(groupID int, targetID int) (Target, error) {
-	if groupID < 1 {
-		return Target{}, fmt.Errorf("invalid target group id")
-	}
-	if targetID < 1 {
-		return Target{}, fmt.Errorf("invalid target id")
-	}
-	body, err := connection.Get[Target](s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets/%d", groupID, targetID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TargetNotFoundError{ID: groupID}))
-	return body.Data, err
+	return s.targetGroupTargetRes().Get(groupID, targetID)
 }
 
 // CreateTargetGroupTarget creates a target
 func (s *Service) CreateTargetGroupTarget(groupID int, req CreateTargetRequest) (int, error) {
-	if groupID < 1 {
-		return 0, fmt.Errorf("invalid target group id")
-	}
-	body, err := connection.Post[Target](s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets", groupID), &req, connection.NotFoundResponseHandler(&TargetNotFoundError{ID: groupID}))
-	return body.Data.ID, err
+	target, err := s.targetGroupTargetRes().Create(groupID, &req)
+	return target.ID, err
 }
 
 // PatchTargetGroupTarget patches a target
 func (s *Service) PatchTargetGroupTarget(groupID int, targetID int, req PatchTargetRequest) error {
-	if groupID < 1 {
-		return fmt.Errorf("invalid target group id")
-	}
-	if targetID < 1 {
-		return fmt.Errorf("invalid target id")
-	}
-	return connection.PatchRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets/%d", groupID, targetID), &req, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TargetNotFoundError{ID: groupID}))
+	return s.targetGroupTargetRes().Patch(groupID, targetID, &req)
 }
 
 // DeleteTargetGroupTarget deletes a target
 func (s *Service) DeleteTargetGroupTarget(groupID int, targetID int) error {
-	if groupID < 1 {
-		return fmt.Errorf("invalid target group id")
-	}
-	if targetID < 1 {
-		return fmt.Errorf("invalid target id")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/loadbalancers/v2/target-groups/%d/targets/%d", groupID, targetID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TargetNotFoundError{ID: groupID}))
+	return s.targetGroupTargetRes().Delete(groupID, targetID)
 }

--- a/pkg/service/pss/service_request.go
+++ b/pkg/service/pss/service_request.go
@@ -57,22 +57,20 @@ func (s *Service) GetRequestRepliesPaginated(solutionID int, parameters connecti
 	return s.GetRequestConversationPaginated(solutionID, parameters)
 }
 
+func (s *Service) requestConversationRes() *resource.SubResourceList[Reply, int] {
+	return resource.NewIntSubResourceList[Reply](s.connection,
+		func(requestID int) string { return fmt.Sprintf("/pss/v1/requests/%d/conversation", requestID) },
+		"request", "id", func(requestID int) error { return &RequestNotFoundError{ID: requestID} })
+}
+
 // GetRequestConversation retrieves a list of replies
 func (s *Service) GetRequestConversation(solutionID int, parameters connection.APIRequestParameters) ([]Reply, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Reply], error) {
-		return s.GetRequestConversationPaginated(solutionID, p)
-	}, parameters)
+	return s.requestConversationRes().List(solutionID, parameters)
 }
 
 // GetRequestConversationPaginated retrieves a paginated list of domains
 func (s *Service) GetRequestConversationPaginated(solutionID int, parameters connection.APIRequestParameters) (*connection.Paginated[Reply], error) {
-	if solutionID < 1 {
-		return nil, fmt.Errorf("invalid request id")
-	}
-	body, err := connection.Get[[]Reply](s.connection, fmt.Sprintf("/pss/v1/requests/%d/conversation", solutionID), parameters, connection.NotFoundResponseHandler(&RequestNotFoundError{ID: solutionID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Reply], error) {
-		return s.GetRequestConversationPaginated(solutionID, p)
-	}), err
+	return s.requestConversationRes().ListPaginated(solutionID, parameters)
 }
 
 // GetRequestFeedback retrieves feedback for a request

--- a/pkg/service/safedns/service_template.go
+++ b/pkg/service/safedns/service_template.go
@@ -12,6 +12,17 @@ func (s *Service) templateRes() *resource.Resource[Template, int] {
 		func(id int) error { return &TemplateNotFoundError{TemplateID: id} })
 }
 
+func (s *Service) templateRecordRes() *resource.SubResource[Record, int, int] {
+	return resource.NewIntIntSubResource[Record](
+		s.connection,
+		func(templateID int) string { return fmt.Sprintf("/safedns/v1/templates/%d/records", templateID) },
+		"template", "id", func(templateID int) error { return &TemplateNotFoundError{TemplateID: templateID} },
+		"record", "id", func(templateID int, recordID int) error {
+			return &TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}
+		},
+	)
+}
+
 // GetTemplates retrieves a list of templates
 func (s *Service) GetTemplates(parameters connection.APIRequestParameters) ([]Template, error) {
 	return s.templateRes().List(parameters)
@@ -49,62 +60,32 @@ func (s *Service) DeleteTemplate(templateID int) error {
 
 // GetTemplateRecords retrieves a list of records
 func (s *Service) GetTemplateRecords(templateID int, parameters connection.APIRequestParameters) ([]Record, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-		return s.GetTemplateRecordsPaginated(templateID, p)
-	}, parameters)
+	return s.templateRecordRes().List(templateID, parameters)
 }
 
 // GetTemplateRecordsPaginated retrieves a paginated list of templates
 func (s *Service) GetTemplateRecordsPaginated(templateID int, parameters connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-	if templateID < 1 {
-		return nil, fmt.Errorf("invalid template id")
-	}
-	body, err := connection.Get[[]Record](s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records", templateID), parameters, connection.NotFoundResponseHandler(&TemplateNotFoundError{TemplateID: templateID}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-		return s.GetTemplateRecordsPaginated(templateID, p)
-	}), err
+	return s.templateRecordRes().ListPaginated(templateID, parameters)
 }
 
 // GetTemplateRecord retrieves a single zone record by ID
 func (s *Service) GetTemplateRecord(templateID int, recordID int) (Record, error) {
-	if templateID < 1 {
-		return Record{}, fmt.Errorf("invalid template id")
-	}
-	if recordID < 1 {
-		return Record{}, fmt.Errorf("invalid record id")
-	}
-	body, err := connection.Get[Record](s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records/%d", templateID, recordID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}))
-	return body.Data, err
+	return s.templateRecordRes().Get(templateID, recordID)
 }
 
-// CreateTemplateRecord creates a new SafeDNS zone record
+// CreateTemplateRecord creates a new SafeDNS template record
 func (s *Service) CreateTemplateRecord(templateID int, req CreateRecordRequest) (int, error) {
-	if templateID < 1 {
-		return 0, fmt.Errorf("invalid template id")
-	}
-	body, err := connection.Post[Template](s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records", templateID), &req, connection.NotFoundResponseHandler(&TemplateNotFoundError{TemplateID: templateID}))
-	return body.Data.ID, err
+	data, err := s.templateRecordRes().Create(templateID, &req)
+	return data.ID, err
 }
 
 // PatchTemplateRecord patches a SafeDNS template record
 func (s *Service) PatchTemplateRecord(templateID int, recordID int, patch PatchRecordRequest) (int, error) {
-	if templateID < 1 {
-		return 0, fmt.Errorf("invalid template id")
-	}
-	if recordID < 1 {
-		return 0, fmt.Errorf("invalid record id")
-	}
-	body, err := connection.Patch[Template](s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records/%d", templateID, recordID), &patch, connection.NotFoundResponseHandler(&TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}))
-	return body.Data.ID, err
+	data, err := s.templateRecordRes().PatchReturning(templateID, recordID, &patch)
+	return data.ID, err
 }
 
 // DeleteTemplateRecord removes a SafeDNS template record
 func (s *Service) DeleteTemplateRecord(templateID int, recordID int) error {
-	if templateID < 1 {
-		return fmt.Errorf("invalid template id")
-	}
-	if recordID < 1 {
-		return fmt.Errorf("invalid record id")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/safedns/v1/templates/%d/records/%d", templateID, recordID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&TemplateRecordNotFoundError{TemplateID: templateID, RecordID: recordID}))
+	return s.templateRecordRes().Delete(templateID, recordID)
 }

--- a/pkg/service/safedns/service_zone.go
+++ b/pkg/service/safedns/service_zone.go
@@ -12,6 +12,28 @@ func (s *Service) zoneRes() *resource.Resource[Zone, string] {
 		func(id string) error { return &ZoneNotFoundError{ZoneName: id} })
 }
 
+func (s *Service) zoneRecordRes() *resource.SubResource[Record, string, int] {
+	return resource.NewStringIntSubResource[Record](
+		s.connection,
+		func(zoneName string) string { return fmt.Sprintf("/safedns/v1/zones/%s/records", zoneName) },
+		"zone", "name", func(zoneName string) error { return &ZoneNotFoundError{ZoneName: zoneName} },
+		"record", "id", func(zoneName string, recordID int) error {
+			return &ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}
+		},
+	)
+}
+
+func (s *Service) zoneNoteRes() *resource.SubResource[Note, string, int] {
+	return resource.NewStringIntSubResource[Note](
+		s.connection,
+		func(zoneName string) string { return fmt.Sprintf("/safedns/v1/zones/%s/notes", zoneName) },
+		"zone", "name", func(zoneName string) error { return &ZoneNotFoundError{ZoneName: zoneName} },
+		"note", "id", func(zoneName string, noteID int) error {
+			return &ZoneNoteNotFoundError{ZoneName: zoneName, NoteID: noteID}
+		},
+	)
+}
+
 // GetZones retrieves a list of zones
 func (s *Service) GetZones(parameters connection.APIRequestParameters) ([]Zone, error) {
 	return s.zoneRes().List(parameters)
@@ -47,113 +69,59 @@ func (s *Service) DeleteZone(zoneName string) error {
 
 // GetZoneRecords retrieves a list of records
 func (s *Service) GetZoneRecords(zoneName string, parameters connection.APIRequestParameters) ([]Record, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-		return s.GetZoneRecordsPaginated(zoneName, p)
-	}, parameters)
+	return s.zoneRecordRes().List(zoneName, parameters)
 }
 
 // GetZoneRecordsPaginated retrieves a paginated list of zones
 func (s *Service) GetZoneRecordsPaginated(zoneName string, parameters connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-	if zoneName == "" {
-		return nil, fmt.Errorf("invalid zone name")
-	}
-	body, err := connection.Get[[]Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records", zoneName), parameters, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Record], error) {
-		return s.GetZoneRecordsPaginated(zoneName, p)
-	}), err
+	return s.zoneRecordRes().ListPaginated(zoneName, parameters)
 }
 
 // GetZoneRecord retrieves a single zone record by ID
 func (s *Service) GetZoneRecord(zoneName string, recordID int) (Record, error) {
-	if zoneName == "" {
-		return Record{}, fmt.Errorf("invalid zone name")
-	}
-	if recordID < 1 {
-		return Record{}, fmt.Errorf("invalid record id")
-	}
-	body, err := connection.Get[Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, recordID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}))
-	return body.Data, err
+	return s.zoneRecordRes().Get(zoneName, recordID)
 }
 
 // CreateZoneRecord creates a new SafeDNS zone record
 func (s *Service) CreateZoneRecord(zoneName string, req CreateRecordRequest) (int, error) {
-	if zoneName == "" {
-		return 0, fmt.Errorf("invalid zone name")
-	}
-	body, err := connection.Post[Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records", zoneName), &req, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
-	return body.Data.ID, err
+	data, err := s.zoneRecordRes().Create(zoneName, &req)
+	return data.ID, err
 }
 
 // UpdateZoneRecord updates a SafeDNS zone record
 func (s *Service) UpdateZoneRecord(zoneName string, record Record) (int, error) {
-	if zoneName == "" {
-		return 0, fmt.Errorf("invalid zone name")
-	}
-	if record.ID < 1 {
-		return 0, fmt.Errorf("invalid record id")
-	}
-	body, err := connection.Put[Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, record.ID), &record, connection.NotFoundResponseHandler(&ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: record.ID}))
-	return body.Data.ID, err
+	data, err := s.zoneRecordRes().Update(zoneName, record.ID, &record)
+	return data.ID, err
 }
 
 // PatchZoneRecord patches a SafeDNS zone record
 func (s *Service) PatchZoneRecord(zoneName string, recordID int, patch PatchRecordRequest) (int, error) {
-	if zoneName == "" {
-		return 0, fmt.Errorf("invalid zone name")
-	}
-	if recordID < 1 {
-		return 0, fmt.Errorf("invalid record id")
-	}
-	body, err := connection.Put[Record](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, recordID), &patch, connection.NotFoundResponseHandler(&ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}))
-	return body.Data.ID, err
+	data, err := s.zoneRecordRes().Update(zoneName, recordID, &patch)
+	return data.ID, err
 }
 
 // DeleteZoneRecord removes a SafeDNS zone record
 func (s *Service) DeleteZoneRecord(zoneName string, recordID int) error {
-	if zoneName == "" {
-		return fmt.Errorf("invalid zone name")
-	}
-	if recordID < 1 {
-		return fmt.Errorf("invalid record id")
-	}
-	return connection.DeleteRaw(s.connection, fmt.Sprintf("/safedns/v1/zones/%s/records/%d", zoneName, recordID), nil, &connection.APIResponseBody{}, connection.NotFoundResponseHandler(&ZoneRecordNotFoundError{ZoneName: zoneName, RecordID: recordID}))
+	return s.zoneRecordRes().Delete(zoneName, recordID)
 }
 
 // GetZoneNotes retrieves a list of notes
 func (s *Service) GetZoneNotes(zoneName string, parameters connection.APIRequestParameters) ([]Note, error) {
-	return connection.InvokeRequestAll(func(p connection.APIRequestParameters) (*connection.Paginated[Note], error) {
-		return s.GetZoneNotesPaginated(zoneName, p)
-	}, parameters)
+	return s.zoneNoteRes().List(zoneName, parameters)
 }
 
 // GetZoneNotesPaginated retrieves a paginated list of zones
 func (s *Service) GetZoneNotesPaginated(zoneName string, parameters connection.APIRequestParameters) (*connection.Paginated[Note], error) {
-	if zoneName == "" {
-		return nil, fmt.Errorf("invalid zone name")
-	}
-	body, err := connection.Get[[]Note](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/notes", zoneName), parameters, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
-	return connection.NewPaginated(body, parameters, func(p connection.APIRequestParameters) (*connection.Paginated[Note], error) {
-		return s.GetZoneNotesPaginated(zoneName, p)
-	}), err
+	return s.zoneNoteRes().ListPaginated(zoneName, parameters)
 }
 
 // GetZoneNote retrieves a single zone note by ID
 func (s *Service) GetZoneNote(zoneName string, noteID int) (Note, error) {
-	if zoneName == "" {
-		return Note{}, fmt.Errorf("invalid zone name")
-	}
-	if noteID < 1 {
-		return Note{}, fmt.Errorf("invalid note id")
-	}
-	body, err := connection.Get[Note](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/notes/%d", zoneName, noteID), connection.APIRequestParameters{}, connection.NotFoundResponseHandler(&ZoneNoteNotFoundError{ZoneName: zoneName, NoteID: noteID}))
-	return body.Data, err
+	return s.zoneNoteRes().Get(zoneName, noteID)
 }
 
 // CreateZoneNote creates a new SafeDNS zone note
 func (s *Service) CreateZoneNote(zoneName string, req CreateNoteRequest) (int, error) {
-	if zoneName == "" {
-		return 0, fmt.Errorf("invalid zone name")
-	}
-	body, err := connection.Post[Note](s.connection, fmt.Sprintf("/safedns/v1/zones/%s/notes", zoneName), &req, connection.NotFoundResponseHandler(&ZoneNotFoundError{ZoneName: zoneName}))
-	return body.Data.ID, err
+	data, err := s.zoneNoteRes().Create(zoneName, &req)
+	return data.ID, err
 }


### PR DESCRIPTION
Add generic SubResource[T, ParentID, ChildID] and SubResourceList[T, ParentID] types to pkg/service/internal/resource/ to eliminate repeated sub-resource boilerplate across all services.

Constructors:
- NewStringSubResourceList / NewIntSubResourceList (validated)
- NewUncheckedStringSubResourceList (no validation, for firewall rule ports, network rule ports, affinity rule members, network NICs)
- NewStringIntSubResource / NewIntIntSubResource / NewStringStringSubResource

Methods: List, ListPaginated, Get, Create, Update (PUT), Patch (PATCH→error), PatchReturning (PATCH→T), Delete

Services migrated (public interfaces unchanged):
- safedns: zone records, zone notes, template records
- ddosx: domain records, properties, WAF rule sets/rules/advanced rules, ACL GeoIP/IP rules, CDN rules, HSTS rules
- loadbalancer: listener certs/binds/access-IPs/ACLs, targetgroup targets/ACLs
- ecloud: vpc/instance/firewallpolicy/firewallrule/networkpolicy/networkrule/ router/vpngateway/vpnsession/affinityrulemember/volume/image/ availabilityzone/host/hostgroup/network/nic/floatingip/volumegroup/ vpnendpoint/vpngatewayspecs/vpnservice/dhcp sub-resources
- pss: request replies/conversation
- draas: solution backup resources/failover plans/compute resources/hardware plans

Also adds subresource_test.go covering all CRUD operations.

All 21 test packages continue to pass.